### PR TITLE
feat(infra): ambiente di sviluppo locale e validatore configurazione (#24)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,21 +1,36 @@
 # Token del bot Telegram (da @BotFather)
 BOT_TOKEN=
 
-# Percorso locale del file JSON del service account Firebase
+# Database Firestore:
+# - Per sviluppo locale con emulatore (senza chiavi cloud):
+#   FIRESTORE_EMULATOR_HOST=127.0.0.1:8571
+# - Per sviluppo con service account reale:
+#   FIREBASE_CREDENTIALS_PATH=firebase-key.json
+# - In produzione su Cloud Run: se FIREBASE_CREDENTIALS_PATH non e' impostato,
+#   il runtime utilizza le Application Default Credentials (ADC) dell'ambiente.
 FIREBASE_CREDENTIALS_PATH=firebase-key.json
+# FIRESTORE_EMULATOR_HOST=127.0.0.1:8571
 
 # URL pubblico che Telegram usa per il webhook (es. https://tuo-servizio.run.app/webhook)
+# In locale puo' rimanere vuoto: bot.py funzionera' comunque senza webhook Telegram.
 WEBHOOK_URL=
 
-# Generare UNA VOLTA due valori distinti con: python -c "import secrets; print(secrets.token_urlsafe(48))"
-# WEBHOOK_SECRET viene inviato a Telegram e verificato sul webhook. Non committare i valori.
+# Segreti di sicurezza e code Cloud Tasks:
+# NOTA: Per lo sviluppo locale isolato (make test, make webapp, make emulator, make admin)
+# queste variabili NON sono necessarie.
+# Tuttavia, per avviare il server FastAPI completo bot.py (make api), il lifespan
+# richiede WEBHOOK_SECRET (32-256 char URL-safe) e task_queue.validate_configuration()
+# richiede TASK_SECRET, TASKS_QUEUE, BROADCAST_QUEUE e PUBLIC_BASE_URL (https://).
+#
+# Esempi per avviare bot.py in locale con valori conformi:
+# WEBHOOK_SECRET=local-dev-webhook-secret-32-characters-minimum
+# TASK_SECRET=local-dev-task-secret-32-characters-minimum
+# TASKS_QUEUE=projects/dev/locations/europe-west1/queues/tasks
+# BROADCAST_QUEUE=projects/dev/locations/europe-west1/queues/broadcast
+# PUBLIC_BASE_URL=https://localhost:8000
 WEBHOOK_SECRET=
-# TASK_SECRET protegge gli endpoint worker Cloud Tasks (distinto da GENERATION_SECRET).
 TASK_SECRET=
-# Nomi completi delle code Cloud Tasks, configurate prima del deploy:
-# projects/PROJECT_ID/locations/europe-west1/queues/telegram-updates
 TASKS_QUEUE=
-# projects/PROJECT_ID/locations/europe-west1/queues/daily-broadcast
 BROADCAST_QUEUE=
 
 # ID Telegram (numerici) abilitati ai comandi /admin_*, separati da virgola
@@ -27,8 +42,9 @@ GENERATION_SECRET=
 # Porta su cui gira il server (impostata automaticamente da Cloud Run)
 PORT=8000
 
-# Base pubblica del servizio, senza barra finale (es. https://tuo-servizio.run.app).
-# Serve alla mini app Telegram: se e' vuota, il bottone "Apri l'app" non compare.
+# Base pubblica del servizio, con schema https:// (es. https://tuo-servizio.run.app).
+# Serve alla mini app Telegram e a task_queue.validate_configuration().
+# Per lo sviluppo dell'interfaccia senza bot.py puoi usare scripts/preview_webapp.py (make webapp).
 PUBLIC_BASE_URL=
 
 # Username del bot senza @ (es. guess_the_player_bot): serve ai link di condivisione del

--- a/Makefile
+++ b/Makefile
@@ -7,13 +7,16 @@
 
 PYTHON ?= python
 
-.PHONY: help check-env test test-cov test-node lint typecheck syntax dataset-check check api admin webapp emulator
+.PHONY: help check-env check-api test test-cov test-node lint typecheck syntax dataset-check check api admin webapp emulator
 
 help:
 	@$(PYTHON) -m tools.dev --help
 
 check-env:
 	@$(PYTHON) -m tools.check_environment
+
+check-api:
+	@$(PYTHON) -m tools.check_environment --mode api
 
 test:
 	@$(PYTHON) -m pytest -q
@@ -40,7 +43,7 @@ check:
 	@$(PYTHON) -m tools.dev check
 
 api:
-	@$(PYTHON) -m uvicorn bot:app --reload --port 8000
+	@$(PYTHON) -m tools.dev api
 
 admin:
 	@$(PYTHON) -m streamlit run admin_ui.py

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,52 @@
+# Makefile per Guess the Player
+# Compatibile con Linux, macOS, WSL e Windows con GNU make.
+# Su Windows senza make e' possibile usare:
+#   .\dev.ps1 <comando>
+# oppure direttamente:
+#   python -m tools.dev <comando>
+
+PYTHON ?= python
+
+.PHONY: help check-env test test-cov test-node lint typecheck syntax dataset-check check api admin webapp emulator
+
+help:
+	@$(PYTHON) -m tools.dev --help
+
+check-env:
+	@$(PYTHON) -m tools.check_environment
+
+test:
+	@$(PYTHON) -m pytest -q
+
+test-cov:
+	@$(PYTHON) -m pytest -q --cov=services --cov=handlers --cov-report=term-missing
+
+test-node:
+	node --test tests/client.test.cjs
+
+lint:
+	@$(PYTHON) -m ruff check .
+
+typecheck:
+	@$(PYTHON) -m mypy services/
+
+syntax:
+	@$(PYTHON) -m compileall -q bot.py config.py services handlers scripts admin_pages admin_ui.py tools
+
+dataset-check:
+	@$(PYTHON) scripts/dataset_report.py --strict
+
+check:
+	@$(PYTHON) -m tools.dev check
+
+api:
+	@$(PYTHON) -m uvicorn bot:app --reload --port 8000
+
+admin:
+	@$(PYTHON) -m streamlit run admin_ui.py
+
+webapp:
+	@$(PYTHON) scripts/preview_webapp.py
+
+emulator:
+	gcloud emulators firestore start --host-port=127.0.0.1:8571

--- a/README.md
+++ b/README.md
@@ -759,8 +759,9 @@ La guida completa per avviare e configurare tutti i componenti dello stack in lo
 Per diagnosticare problemi di configurazione (.env, chiavi Firebase, token Telegram, dataset e dipendenze):
 
 ```bash
-python -m tools.check_environment              # controlli per sviluppo locale (dev)
-python -m tools.check_environment --mode prod   # controlli rigorosi per deploy/produzione
+python -m tools.check_environment              # controlli per sviluppo locale isolato (dev)
+python -m tools.check_environment --mode api    # controlli requisiti per avvio server FastAPI bot.py
+python -m tools.check_environment --mode prod   # controlli per deploy/produzione Cloud Run
 python -m tools.check_environment --json        # output strutturato per script
 ```
 
@@ -768,14 +769,15 @@ python -m tools.check_environment --json        # output strutturato per script
 È disponibile un runner unificato multipiattaforma (`Makefile` su Linux/macOS/WSL, `.\dev.ps1` su Windows PowerShell o `python -m tools.dev`):
 
 ```bash
-make check-env      # oppure .\dev.ps1 check-env     -> valida configurazione e file
+make check-env      # oppure .\dev.ps1 check-env     -> valida ambiente per sviluppo isolato
+make check-api      # oppure .\dev.ps1 check-api     -> valida requisiti avvio server FastAPI bot.py
 make test           # oppure .\dev.ps1 test          -> esegue i test unitari (pytest -q)
 make test-cov       # oppure .\dev.ps1 test-cov      -> test con report di copertura
 make test-node      # oppure .\dev.ps1 test-node     -> test client Mini App (node)
 make lint           # oppure .\dev.ps1 lint          -> linter ruff
 make typecheck      # oppure .\dev.ps1 typecheck     -> typecheck mypy su services/
 make dataset-check  # oppure .\dev.ps1 dataset-check -> controllo integrita' dataset calciatori
-make check          # oppure .\dev.ps1 check         -> intera suite di verifiche locali
+make check          # oppure .\dev.ps1 check         -> suite standard di validazione locale
 make emulator       # oppure .\dev.ps1 emulator      -> avvia emulatore Firestore locale (porta 8571)
 make api            # oppure .\dev.ps1 api           -> avvia FastAPI/bot con reload (porta 8000)
 make admin          # oppure .\dev.ps1 admin         -> avvia dashboard admin Streamlit (admin_ui.py)

--- a/README.md
+++ b/README.md
@@ -750,6 +750,38 @@ correggere qualcosa a mano.
 **subito**, senza redeploy: utile quando un utente segnala una carriera sbagliata. Le sfide
 già presenti nel buffer non cambiano, si controllano con `/admin_next`.
 
+## Sviluppo locale e validatore configurazione
+
+La guida completa per avviare e configurare tutti i componenti dello stack in locale è disponibile in:
+👉 [`docs/local-development.md`](docs/local-development.md)
+
+### 1. Verifica preventiva dell'ambiente
+Per diagnosticare problemi di configurazione (.env, chiavi Firebase, token Telegram, dataset e dipendenze):
+
+```bash
+python -m tools.check_environment              # controlli per sviluppo locale (dev)
+python -m tools.check_environment --mode prod   # controlli rigorosi per deploy/produzione
+python -m tools.check_environment --json        # output strutturato per script
+```
+
+### 2. Comandi di sviluppo rapidi
+È disponibile un runner unificato multipiattaforma (`Makefile` su Linux/macOS/WSL, `.\dev.ps1` su Windows PowerShell o `python -m tools.dev`):
+
+```bash
+make check-env      # oppure .\dev.ps1 check-env     -> valida configurazione e file
+make test           # oppure .\dev.ps1 test          -> esegue i test unitari (pytest -q)
+make test-cov       # oppure .\dev.ps1 test-cov      -> test con report di copertura
+make test-node      # oppure .\dev.ps1 test-node     -> test client Mini App (node)
+make lint           # oppure .\dev.ps1 lint          -> linter ruff
+make typecheck      # oppure .\dev.ps1 typecheck     -> typecheck mypy su services/
+make dataset-check  # oppure .\dev.ps1 dataset-check -> controllo integrita' dataset calciatori
+make check          # oppure .\dev.ps1 check         -> intera suite di verifiche locali
+make emulator       # oppure .\dev.ps1 emulator      -> avvia emulatore Firestore locale (porta 8571)
+make api            # oppure .\dev.ps1 api           -> avvia FastAPI/bot con reload (porta 8000)
+make admin          # oppure .\dev.ps1 admin         -> avvia dashboard admin Streamlit (admin_ui.py)
+make webapp         # oppure .\dev.ps1 webapp        -> avvia anteprima locale Mini App (porta 8888)
+```
+
 ## Anteprima locale della mini app
 
 ```bash

--- a/dev.ps1
+++ b/dev.ps1
@@ -1,0 +1,26 @@
+<#
+.SYNOPSIS
+    Runner per i comandi di sviluppo locale su Windows PowerShell.
+.DESCRIPTION
+    Inoltra i comandi a tools.dev senza richiedere l'installazione di GNU make.
+.EXAMPLE
+    .\dev.ps1 check-env
+    .\dev.ps1 test
+    .\dev.ps1 check
+    .\dev.ps1 admin
+    .\dev.ps1 webapp
+#>
+
+param(
+    [Parameter(Position=0, ValueFromRemainingArguments=$true)]
+    [string[]]$Arguments
+)
+
+$pythonExe = (Get-Command python -ErrorAction SilentlyContinue).Source
+if (-not $pythonExe) {
+    Write-Error "Python non trovato nel PATH. Installa Python 3.11+ e aggiungilo al PATH."
+    exit 1
+}
+
+& $pythonExe -m tools.dev @Arguments
+exit $LASTEXITCODE

--- a/docs/local-development.md
+++ b/docs/local-development.md
@@ -1,0 +1,188 @@
+# Sviluppo locale e validazione configurazione
+
+Questa guida documenta l'ambiente di sviluppo locale per **Guess the Player**, i comandi disponibili e le istruzioni per avviare ciascun componente dello stack (Firestore Emulator, API, Telegram bot, Mini App e Admin Dashboard) in modo riproducibile su Windows, WSL, Linux e macOS.
+
+---
+
+## 1. Prerequisiti
+
+| Strumento | Versione richiesta | Perché serve |
+|---|---|---|
+| **Python** | **>= 3.11** | Richiesto da `asyncio.timeout` in `bot.py`, sintassi moderne e `pyproject.toml` |
+| **Node.js** | **>= 20** (consigliata 22) | Esecuzione dei test client senza bundler (`node --test tests/client.test.cjs`) |
+| **Java JRE/JDK** | **>= 17** (consigliata 21) | Runtime necessario per eseguire l'emulatore Firestore locale di Google Cloud |
+| **Google Cloud SDK (`gcloud`)** | Qualsiasi recente | Gestione ed esecuzione dell'emulatore Firestore locale (`cloud-firestore-emulator`) |
+
+---
+
+## 2. Configurazione iniziale rapida
+
+### 1. Clona il repository e crea il virtual environment
+
+Su Linux / macOS / WSL:
+```bash
+python3.11 -m venv .venv
+source .venv/bin/activate
+pip install -r requirements-dev.txt
+```
+
+Su Windows (PowerShell):
+```powershell
+py -3.11 -m venv .venv
+.\.venv\Scripts\Activate.ps1
+pip install -r requirements-dev.txt
+```
+
+### 2. Configura le variabili d'ambiente (`.env`)
+
+Copia il template di esempio:
+```bash
+cp .env.example .env       # Linux / macOS / WSL
+copy .env.example .env     # Windows PowerShell / CMD
+```
+
+Per lo sviluppo locale base (senza chiamate verso Telegram e senza invio a code esterne), sono sufficienti:
+- `BOT_TOKEN`: un token Telegram ottenuto da `@BotFather` (es. `123456789:ABCdefGhIJKlmNoPQRsTUVwxyZ`).
+- `FIRESTORE_EMULATOR_HOST`: impostato a `127.0.0.1:8571` per usare l'emulatore locale senza necessità di una chiave JSON di produzione.
+
+Se invece disponi di un progetto Firebase di test/staging con service account:
+- `FIREBASE_CREDENTIALS_PATH=firebase-key.json`
+
+---
+
+## 3. Validatore dell'ambiente (`tools.check_environment`)
+
+Prima di avviare i servizi, puoi verificare preventivamente se tutti i requisiti, file e variabili sono corretti con:
+
+```bash
+python -m tools.check_environment
+```
+
+### Opzioni supportate:
+- `python -m tools.check_environment`: verifica l'ambiente per lo **sviluppo locale** (default `dev`). In questa modalità, l'assenza di code Cloud Tasks o URL pubblici HTTPS viene segnalata come nota informativa, non come blocco.
+- `python -m tools.check_environment --mode prod`: verifica l'ambiente per il **deploy o produzione**, accertando che tutti i segreti (`WEBHOOK_SECRET`, `TASK_SECRET`), code (`TASKS_QUEUE`, `BROADCAST_QUEUE`) e `PUBLIC_BASE_URL` siano configurati con formato rigoroso.
+- `python -m tools.check_environment --strict`: tratta gli avvisi (`WARN`) come errori bloccanti (restituisce codice di uscita `1`).
+- `python -m tools.check_environment --json`: stampa l'esito formattato in JSON per integrazioni CI o script automatici.
+- `python -m tools.check_environment --quiet`: nasconde i controlli passati mostrando solo problemi ed azioni correttive.
+
+### Errori azionabili
+Tutti gli errori e gli avvisi includono una sezione **Azioni Richieste** che fornisce l'esatto comando da lanciare o la riga da inserire nel `.env` per correggere il problema.
+
+---
+
+## 4. Comandi di sviluppo locale
+
+Per garantire massima comodità su ogni sistema operativo sono disponibili tre punti di ingresso equivalenti:
+1. **Runner multipiattaforma Python**: `python -m tools.dev <comando>` (funziona ovunque ci sia Python).
+2. **Make**: `make <comando>` (standard per Linux, macOS, WSL e container).
+3. **PowerShell script**: `.\dev.ps1 <comando>` (conveniente su Windows senza installare Make).
+
+| Comando Make | Comando Python / PowerShell | Descrizione |
+|---|---|---|
+| `make check-env` | `python -m tools.dev check-env`<br>`.\dev.ps1 check-env` | Esegue il validatore dell'ambiente |
+| `make test` | `python -m tools.dev test`<br>`.\dev.ps1 test` | Esegue i test unitari veloci con `pytest -q` |
+| `make test-cov` | `python -m tools.dev test-cov`<br>`.\dev.ps1 test-cov` | Esegue i test con report di code coverage nel terminale |
+| `make test-node` | `python -m tools.dev test-node`<br>`.\dev.ps1 test-node` | Esegue i test client Node.js per la Mini App (`tests/client.test.cjs`) |
+| `make lint` | `python -m tools.dev lint`<br>`.\dev.ps1 lint` | Verifica lo stile del codice con `ruff check .` |
+| `make typecheck` | `python -m tools.dev typecheck`<br>`.\dev.ps1 typecheck` | Controllo tipi statici con `mypy services/` |
+| `make syntax` | `python -m tools.dev syntax`<br>`.\dev.ps1 syntax` | Verifica sintassi con `compileall` su tutti i moduli |
+| `make dataset-check` | `python -m tools.dev dataset-check`<br>`.\dev.ps1 dataset-check` | Controlla integrità e salute del dataset calciatori (`scripts/dataset_report.py --strict`) |
+| `make check` | `python -m tools.dev check`<br>`.\dev.ps1 check` | Esegue **tutte** le verifiche di qualità in sequenza (CI locale completa) |
+| `make emulator` | `python -m tools.dev emulator`<br>`.\dev.ps1 emulator` | Avvia l'emulatore Firestore locale su porta 8571 |
+| `make api` | `python -m tools.dev api`<br>`.\dev.ps1 api` | Avvia il server FastAPI (`bot.py`) con `--reload` su porta 8000 |
+| `make admin` | `python -m tools.dev admin`<br>`.\dev.ps1 admin` | Avvia la dashboard Streamlit su `admin_ui.py` |
+| `make webapp` | `python -m tools.dev webapp`<br>`.\dev.ps1 webapp` | Avvia l'anteprima isolata della Mini App su `http://localhost:8888/app` |
+
+---
+
+## 5. Avvio e funzionamento dei singoli componenti
+
+### 5.1 Emulatore Firestore
+
+L'emulatore simula Firestore in locale sulla JVM, permettendo di testare transazioni reali senza intaccare il database cloud.
+
+1. Installa il componente (una volta sola):
+   ```bash
+   gcloud components install cloud-firestore-emulator
+   ```
+2. Avvia l'emulatore:
+   ```bash
+   make emulator
+   # oppure: python -m tools.dev emulator
+   ```
+3. In altri terminali o nel `.env`, dichiara:
+   ```bash
+   export FIRESTORE_EMULATOR_HOST=127.0.0.1:8571   # Linux/WSL/macOS
+   $env:FIRESTORE_EMULATOR_HOST="127.0.0.1:8571"   # PowerShell
+   ```
+
+Con `FIRESTORE_EMULATOR_HOST` configurato, la suite di test esegue anche `tests/test_firestore_transactions.py` (transazioni di bonus, pagamenti in Stelle e ricevute di update).
+
+---
+
+### 5.2 Anteprima della Mini App (senza Telegram)
+
+Per sviluppare o verificare graficamente la Mini App, i temi del negozio, le cornici o il calendario senza dipendere da Telegram o Firestore:
+
+```bash
+make webapp
+# oppure: python -m tools.dev webapp
+```
+
+Apri il browser su:
+```
+http://localhost:8888/app
+```
+Questo avvia un server FastAPI leggero (`scripts/preview_webapp.py`) che inietta un finto utente con tutti i cosmetici già sbloccati, conservando tutto in memoria.
+
+---
+
+### 5.3 Dashboard Amministrativa (Streamlit)
+
+La dashboard amministrativa locale permette di ispezionare lo stato del gioco, gestire le sfide giornaliere, pianificare eventi e tarare la difficoltà:
+
+```bash
+make admin
+# oppure: python -m tools.dev admin
+```
+
+Verrà aperta l'interfaccia Streamlit (solitamente su `http://localhost:8501`).
+- Se è configurato `FIRESTORE_EMULATOR_HOST`, leggerà e scriverà sull'emulatore locale.
+- Se è configurato `FIREBASE_CREDENTIALS_PATH=firebase-key.json`, scriverà sul progetto Firebase puntato dalla chiave.
+
+---
+
+### 5.4 API e Server Principale (`bot.py`)
+
+Per avviare il server FastAPI completo:
+
+```bash
+make api
+# oppure: python -m tools.dev api
+```
+
+Il server risponde su `http://localhost:8000`:
+- `GET /`: verifica stato (`{"message": "Bot attivo!"}`)
+- `GET /ping`: health check
+- `GET /app`: serve la pagina principale della Mini App (`webapp/index.html`)
+- `POST /app/api/*`: endpoint API della Mini App
+- `POST /webhook`: endpoint per ricevere update webhook da Telegram (richiede `WEBHOOK_SECRET`)
+
+> [!NOTE]
+> In produzione `bot.py` gira su Cloud Run con un'architettura rinforzata descritta in [`docs/runtime-hardening.md`](runtime-hardening.md), basata su segreti a 48 caratteri URL-safe e code Cloud Tasks per l'accodamento duraturo. Per lo sviluppo e i test locali dei client webapp o delle funzioni di gioco, i comandi `make webapp` e `make test` operano in modo isolato e non richiedono risorse cloud.
+
+---
+
+## 6. Risoluzione dei problemi comuni (Troubleshooting)
+
+### 1. `UnicodeEncodeError: 'charmap' codec can't encode character`
+- **Causa**: Console Windows con codepage non-UTF8 (es. cp1252) che non supporta certi caratteri emoji.
+- **Risoluzione**: I tool `tools.check_environment` e `tools.dev` sono progettati con output ASCII-compatibile. In PowerShell puoi forzare la codifica UTF-8 per la sessione con: `[Console]::OutputEncoding = [System.Text.Encoding]::UTF8`.
+
+### 2. `ModuleNotFoundError: No module named 'google.cloud.tasks_v2'`
+- **Causa**: Dipendenze mancanti nell'ambiente Python locale.
+- **Risoluzione**: Esegui `pip install -r requirements-dev.txt` per installare tutte le dipendenze dichiarate in `requirements.txt` e `requirements-dev.txt`.
+
+### 3. `FIRESTORE_EMULATOR_HOST non impostata: emulatore Firestore non disponibile`
+- **Causa**: I test delle transazioni Firestore vengono saltati se la variabile d'ambiente non è impostata.
+- **Risoluzione**: Avvia l'emulatore con `make emulator` e imposta `$env:FIRESTORE_EMULATOR_HOST="127.0.0.1:8571"` nel terminale in cui lanci i test.

--- a/docs/local-development.md
+++ b/docs/local-development.md
@@ -41,12 +41,20 @@ cp .env.example .env       # Linux / macOS / WSL
 copy .env.example .env     # Windows PowerShell / CMD
 ```
 
-Per lo sviluppo locale base (senza chiamate verso Telegram e senza invio a code esterne), sono sufficienti:
+Per lo sviluppo locale base isolato (test, emulatore Firestore, anteprima Mini App `make webapp` e admin `make admin`):
 - `BOT_TOKEN`: un token Telegram ottenuto da `@BotFather` (es. `123456789:ABCdefGhIJKlmNoPQRsTUVwxyZ`).
 - `FIRESTORE_EMULATOR_HOST`: impostato a `127.0.0.1:8571` per usare l'emulatore locale senza necessità di una chiave JSON di produzione.
 
-Se invece disponi di un progetto Firebase di test/staging con service account:
-- `FIREBASE_CREDENTIALS_PATH=firebase-key.json`
+Se invece intendi avviare il **server FastAPI completo `bot.py` (`make api`)**:
+`bot.py` esegue all'avvio controlli rigorosi di lifespan (`task_queue.validate_configuration()`) e richiede:
+- `WEBHOOK_SECRET`: stringa URL-safe da 32 a 256 caratteri.
+- `TASK_SECRET`: stringa URL-safe da 32 a 256 caratteri.
+- `TASKS_QUEUE` e `BROADCAST_QUEUE`: identificatori di coda (es. `projects/dev/locations/eu/queues/tasks`).
+- `PUBLIC_BASE_URL`: URL con schema `https://` (es. `https://localhost:8000` o tunnel HTTPS).
+
+In ambiente di produzione (es. Cloud Run):
+- Le variabili vengono fornite direttamente dall'ambiente di runtime / Secret Manager **senza richiedere alcun file `.env`**.
+- L'accesso a Firestore può avvenire automaticamente tramite **Application Default Credentials (ADC)** assegnate al Service Account del container, senza necessità di impostare `FIREBASE_CREDENTIALS_PATH` su un file JSON locale.
 
 ---
 
@@ -58,10 +66,11 @@ Prima di avviare i servizi, puoi verificare preventivamente se tutti i requisiti
 python -m tools.check_environment
 ```
 
-### Opzioni supportate:
-- `python -m tools.check_environment`: verifica l'ambiente per lo **sviluppo locale** (default `dev`). In questa modalità, l'assenza di code Cloud Tasks o URL pubblici HTTPS viene segnalata come nota informativa, non come blocco.
-- `python -m tools.check_environment --mode prod`: verifica l'ambiente per il **deploy o produzione**, accertando che tutti i segreti (`WEBHOOK_SECRET`, `TASK_SECRET`), code (`TASKS_QUEUE`, `BROADCAST_QUEUE`) e `PUBLIC_BASE_URL` siano configurati con formato rigoroso.
-- `python -m tools.check_environment --strict`: tratta gli avvisi (`WARN`) come errori bloccanti (restituisce codice di uscita `1`).
+### Modalità e opzioni supportate:
+- `python -m tools.check_environment` (oppure `--mode dev`): verifica l'ambiente per lo **sviluppo locale isolato** (test, emulatore, preview webapp). In questa modalità, le code Cloud Tasks o i segreti di webhook sono opzionali (segnalati con nota informativa `[INFO]`).
+- `python -m tools.check_environment --mode api`: verifica i requisiti per avviare il **server FastAPI `bot.py` (`make api`)**, accertando la presenza di `WEBHOOK_SECRET`, `TASK_SECRET`, `TASKS_QUEUE`, `BROADCAST_QUEUE` e `PUBLIC_BASE_URL` (HTTPS) richiesti dal lifespan di avvio.
+- `python -m tools.check_environment --mode prod`: verifica l'ambiente per il **deploy di produzione** (Cloud Run), accertando la validità dei segreti e dei percorsi GCP completi senza richiedere la presenza del file `.env` e supportando l'autenticazione via ADC.
+- `python -m tools.check_environment --strict`: tratta gli avvisi (`WARN`) come errori bloccanti (codice di uscita `1`).
 - `python -m tools.check_environment --json`: stampa l'esito formattato in JSON per integrazioni CI o script automatici.
 - `python -m tools.check_environment --quiet`: nasconde i controlli passati mostrando solo problemi ed azioni correttive.
 
@@ -79,7 +88,8 @@ Per garantire massima comodità su ogni sistema operativo sono disponibili tre p
 
 | Comando Make | Comando Python / PowerShell | Descrizione |
 |---|---|---|
-| `make check-env` | `python -m tools.dev check-env`<br>`.\dev.ps1 check-env` | Esegue il validatore dell'ambiente |
+| `make check-env` | `python -m tools.dev check-env`<br>`.\dev.ps1 check-env` | Esegue il validatore dell'ambiente (modalità dev: sviluppo isolato) |
+| `make check-api` | `python -m tools.dev check-api`<br>`.\dev.ps1 check-api` | Valida i requisiti completi per l'avvio del server FastAPI `bot.py` |
 | `make test` | `python -m tools.dev test`<br>`.\dev.ps1 test` | Esegue i test unitari veloci con `pytest -q` |
 | `make test-cov` | `python -m tools.dev test-cov`<br>`.\dev.ps1 test-cov` | Esegue i test con report di code coverage nel terminale |
 | `make test-node` | `python -m tools.dev test-node`<br>`.\dev.ps1 test-node` | Esegue i test client Node.js per la Mini App (`tests/client.test.cjs`) |
@@ -87,11 +97,14 @@ Per garantire massima comodità su ogni sistema operativo sono disponibili tre p
 | `make typecheck` | `python -m tools.dev typecheck`<br>`.\dev.ps1 typecheck` | Controllo tipi statici con `mypy services/` |
 | `make syntax` | `python -m tools.dev syntax`<br>`.\dev.ps1 syntax` | Verifica sintassi con `compileall` su tutti i moduli |
 | `make dataset-check` | `python -m tools.dev dataset-check`<br>`.\dev.ps1 dataset-check` | Controlla integrità e salute del dataset calciatori (`scripts/dataset_report.py --strict`) |
-| `make check` | `python -m tools.dev check`<br>`.\dev.ps1 check` | Esegue **tutte** le verifiche di qualità in sequenza (CI locale completa) |
+| `make check` | `python -m tools.dev check`<br>`.\dev.ps1 check` | Esegue la **suite standard di validazione locale** (ambiente, sintassi, lint, mypy, dataset, client test, pytest) |
 | `make emulator` | `python -m tools.dev emulator`<br>`.\dev.ps1 emulator` | Avvia l'emulatore Firestore locale su porta 8571 |
 | `make api` | `python -m tools.dev api`<br>`.\dev.ps1 api` | Avvia il server FastAPI (`bot.py`) con `--reload` su porta 8000 |
 | `make admin` | `python -m tools.dev admin`<br>`.\dev.ps1 admin` | Avvia la dashboard Streamlit su `admin_ui.py` |
 | `make webapp` | `python -m tools.dev webapp`<br>`.\dev.ps1 webapp` | Avvia l'anteprima isolata della Mini App su `http://localhost:8888/app` |
+
+> [!NOTE]
+> `make check` (o `python -m tools.dev check`) è la **suite di validazione locale standard** concepita per un ciclo di feedback immediato prima del commit. A differenza di `check`, la pipeline GitHub Actions (`.github/workflows/ci.yml`) avvia in aggiunta un'istanza dell'emulatore Firestore su JVM per verificare le transazioni concorrenti reali ed applica la soglia di copertura minima del 70% (`--cov-fail-under=70`). In locale puoi eseguire i test con copertura usando `make test-cov`.
 
 ---
 
@@ -154,8 +167,29 @@ Verrà aperta l'interfaccia Streamlit (solitamente su `http://localhost:8501`).
 
 ### 5.4 API e Server Principale (`bot.py`)
 
-Per avviare il server FastAPI completo:
+Il server principale `bot.py` include l'applicazione FastAPI, il webhook Telegram e gli endpoint della Mini App.
 
+#### Requisiti di avvio del lifespan
+All'avvio (`lifespan`), `bot.py` verifica la sicurezza e l'integrazione con Cloud Tasks:
+1. `WEBHOOK_SECRET`: stringa URL-safe da 32 a 256 caratteri;
+2. `services.task_queue.validate_configuration()`: verifica `TASK_SECRET` (32-256 caratteri), `TASKS_QUEUE`, `BROADCAST_QUEUE` e `PUBLIC_BASE_URL` (deve iniziare con `https://`).
+
+Prima di lanciare `make api`, puoi verificare se l'ambiente soddisfa questi requisiti con:
+```bash
+make check-api
+# oppure: python -m tools.dev check-api
+```
+
+Per lo sviluppo locale, puoi impostare nel file `.env` valori sintetici conformi:
+```env
+WEBHOOK_SECRET=local-dev-webhook-secret-32-characters-minimum
+TASK_SECRET=local-dev-task-secret-32-characters-minimum
+TASKS_QUEUE=projects/dev/locations/europe-west1/queues/tasks
+BROADCAST_QUEUE=projects/dev/locations/europe-west1/queues/broadcast
+PUBLIC_BASE_URL=https://localhost:8000
+```
+
+Avvia quindi il server:
 ```bash
 make api
 # oppure: python -m tools.dev api
@@ -168,8 +202,8 @@ Il server risponde su `http://localhost:8000`:
 - `POST /app/api/*`: endpoint API della Mini App
 - `POST /webhook`: endpoint per ricevere update webhook da Telegram (richiede `WEBHOOK_SECRET`)
 
-> [!NOTE]
-> In produzione `bot.py` gira su Cloud Run con un'architettura rinforzata descritta in [`docs/runtime-hardening.md`](runtime-hardening.md), basata su segreti a 48 caratteri URL-safe e code Cloud Tasks per l'accodamento duraturo. Per lo sviluppo e i test locali dei client webapp o delle funzioni di gioco, i comandi `make webapp` e `make test` operano in modo isolato e non richiedono risorse cloud.
+> [!TIP]
+> Se desideri soltanto testare la grafica o la logica client della Mini App in locale senza dover configurare i segreti di Cloud Tasks di `bot.py`, usa il comando `make webapp` (`scripts/preview_webapp.py`), che opera in modalità completamente autonoma e isolata.
 
 ---
 
@@ -183,6 +217,10 @@ Il server risponde su `http://localhost:8000`:
 - **Causa**: Dipendenze mancanti nell'ambiente Python locale.
 - **Risoluzione**: Esegui `pip install -r requirements-dev.txt` per installare tutte le dipendenze dichiarate in `requirements.txt` e `requirements-dev.txt`.
 
-### 3. `FIRESTORE_EMULATOR_HOST non impostata: emulatore Firestore non disponibile`
+### 3. `[ERRORE AVVIO API] Requisiti del runtime bot.py non soddisfatti`
+- **Causa**: `bot.py` richiede `WEBHOOK_SECRET`, `TASK_SECRET`, `TASKS_QUEUE`, `BROADCAST_QUEUE` e `PUBLIC_BASE_URL` (`https://`).
+- **Risoluzione**: Esegui `make check-api` per diagnosticare i campi mancanti ed imposta valori sintetici nel `.env` come illustrato nella Sezione 5.4. Per l'anteprima statica della Mini App senza server bot usa `make webapp`.
+
+### 4. `FIRESTORE_EMULATOR_HOST non impostata: emulatore Firestore non disponibile`
 - **Causa**: I test delle transazioni Firestore vengono saltati se la variabile d'ambiente non è impostata.
 - **Risoluzione**: Avvia l'emulatore con `make emulator` e imposta `$env:FIRESTORE_EMULATOR_HOST="127.0.0.1:8571"` nel terminale in cui lanci i test.

--- a/tests/test_check_environment.py
+++ b/tests/test_check_environment.py
@@ -1,0 +1,278 @@
+"""Test per il validatore di ambiente e configurazione (tools.check_environment)."""
+import json
+import os
+import sys
+from unittest.mock import patch
+
+import pytest
+
+from tools.check_environment import CheckStatus, EnvironmentValidator, main
+
+
+@pytest.fixture(autouse=True)
+def isolate_env():
+    """Isola os.environ per evitare che le variabili caricate dai test alterino altri moduli della suite."""
+    old_env = os.environ.copy()
+    yield
+    os.environ.clear()
+    os.environ.update(old_env)
+
+
+@pytest.fixture
+def temp_project(tmp_path):
+    """Crea una struttura fittizia di progetto valida."""
+    # Data directory
+    data_dir = tmp_path / "data"
+    data_dir.mkdir()
+    (data_dir / "players.json").write_text(
+        json.dumps({
+            "_comment": "Test dataset",
+            "players": [
+                {
+                    "id": "player_1",
+                    "full_name": "Paolo Maldini",
+                    "aliases": ["Maldini"],
+                    "career": [{"team": "Milan", "years": "1984-2009"}],
+                }
+            ],
+        }),
+        encoding="utf-8",
+    )
+    (data_dir / "config.json").write_text(json.dumps({"rules": "standard"}), encoding="utf-8")
+    (data_dir / "event_templates.json").write_text(json.dumps({"events": []}), encoding="utf-8")
+    (data_dir / "shop.json").write_text(json.dumps({"items": []}), encoding="utf-8")
+
+    # Webapp directory
+    webapp_dir = tmp_path / "webapp"
+    webapp_dir.mkdir()
+    for name in [
+        "index.html",
+        "client.js",
+        "strings.js",
+        "arena.js",
+        "referrals.js",
+        "legal.css",
+        "terms.html",
+        "privacy.html",
+    ]:
+        (webapp_dir / name).write_text("/* test */", encoding="utf-8")
+
+    # .env
+    env_file = tmp_path / ".env"
+    env_file.write_text(
+        "BOT_TOKEN=123456789:ABCdefGhIJKlmNoPQRsTUVwxyZ123456789\n"
+        "BOT_USERNAME=guess_the_player_bot\n"
+        "ADMIN_TELEGRAM_IDS=12345,67890\n",
+        encoding="utf-8",
+    )
+    return tmp_path
+
+
+def test_python_version_check_passes_on_current_python(temp_project):
+    validator = EnvironmentValidator(project_root=temp_project, mode="dev")
+    validator.check_python_version()
+    assert len(validator.results) == 1
+    item = validator.results[0]
+    assert item.status == CheckStatus.PASS
+    assert "soddisfa il requisito minimo" in item.message
+
+
+def test_python_version_check_fails_on_old_python(temp_project):
+    validator = EnvironmentValidator(project_root=temp_project, mode="dev")
+    with patch.object(sys, "version_info", (3, 10, 8)):
+        validator.check_python_version()
+    assert len(validator.results) == 1
+    item = validator.results[0]
+    assert item.status == CheckStatus.FAIL
+    assert "richiede Python 3.11" in item.message
+    assert item.remediation is not None
+
+
+def test_datasets_check_passes_on_valid_structure(temp_project):
+    validator = EnvironmentValidator(project_root=temp_project, mode="dev")
+    validator.check_datasets_and_files()
+    assert not validator.has_failures
+    for item in validator.results:
+        assert item.status == CheckStatus.PASS
+
+
+def test_datasets_check_fails_on_missing_file(temp_project):
+    (temp_project / "data" / "players.json").unlink()
+    validator = EnvironmentValidator(project_root=temp_project, mode="dev")
+    validator.check_datasets_and_files()
+    failures = [r for r in validator.results if r.status == CheckStatus.FAIL]
+    assert len(failures) == 1
+    assert "data/players.json" in failures[0].name
+    assert failures[0].remediation is not None
+
+
+def test_datasets_check_fails_on_corrupted_json(temp_project):
+    (temp_project / "data" / "config.json").write_text("{corrupted: json,", encoding="utf-8")
+    validator = EnvironmentValidator(project_root=temp_project, mode="dev")
+    validator.check_datasets_and_files()
+    failures = [r for r in validator.results if r.status == CheckStatus.FAIL]
+    assert len(failures) == 1
+    assert "data/config.json" in failures[0].name
+    assert "JSON non valido" in failures[0].message
+
+
+def test_datasets_check_fails_on_missing_webapp_assets(temp_project):
+    (temp_project / "webapp" / "index.html").unlink()
+    validator = EnvironmentValidator(project_root=temp_project, mode="dev")
+    validator.check_datasets_and_files()
+    failures = [r for r in validator.results if r.status == CheckStatus.FAIL]
+    assert any("Static Files" in f.name for f in failures)
+
+
+def test_telegram_config_validation(temp_project, monkeypatch):
+    monkeypatch.setenv("BOT_TOKEN", "123456:ABC-DEF1234ghIkl-zyx57W2v1u1234567")
+    monkeypatch.setenv("BOT_USERNAME", "test_bot")
+    monkeypatch.setenv("ADMIN_TELEGRAM_IDS", "1001, 1002")
+
+    validator = EnvironmentValidator(project_root=temp_project, mode="dev")
+    validator.check_telegram_configuration()
+
+    statuses = {r.name: r.status for r in validator.results}
+    assert statuses["BOT_TOKEN"] == CheckStatus.PASS
+    assert statuses["BOT_USERNAME"] == CheckStatus.PASS
+    assert statuses["ADMIN_TELEGRAM_IDS"] == CheckStatus.PASS
+
+
+def test_telegram_config_missing_token_fails(temp_project, monkeypatch):
+    validator = EnvironmentValidator(project_root=temp_project, mode="dev")
+    monkeypatch.delenv("BOT_TOKEN", raising=False)
+    validator.check_telegram_configuration()
+
+    failures = [r for r in validator.results if r.name == "BOT_TOKEN"]
+    assert len(failures) == 1
+    assert failures[0].status == CheckStatus.FAIL
+
+
+def test_telegram_config_at_sign_in_username_warns(temp_project, monkeypatch):
+    validator = EnvironmentValidator(project_root=temp_project, mode="dev")
+    monkeypatch.setenv("BOT_TOKEN", "123456:valid_format_test_token_1234567890")
+    monkeypatch.setenv("BOT_USERNAME", "@test_bot")
+    validator.check_telegram_configuration()
+
+    username_check = next(r for r in validator.results if r.name == "BOT_USERNAME")
+    assert username_check.status == CheckStatus.WARN
+    assert "@" in username_check.message
+
+
+def test_firebase_emulator_check(temp_project, monkeypatch):
+    validator = EnvironmentValidator(project_root=temp_project, mode="dev")
+    monkeypatch.setenv("FIRESTORE_EMULATOR_HOST", "127.0.0.1:8571")
+    monkeypatch.delenv("FIREBASE_CREDENTIALS_PATH", raising=False)
+    validator.check_firebase_configuration()
+
+    # Se l'emulatore non e' acceso durante il test unitario, riceve un WARN actionable
+    emulator_result = next(r for r in validator.results if "Firestore Emulator" in r.name)
+    assert emulator_result.status in (CheckStatus.PASS, CheckStatus.WARN)
+    assert "FIRESTORE_EMULATOR_HOST" in emulator_result.message or "attivo" in emulator_result.message
+
+
+def test_firebase_credentials_file_validation(temp_project, monkeypatch):
+    cred_file = temp_project / "fake-key.json"
+    cred_file.write_text(json.dumps({
+        "type": "service_account",
+        "project_id": "test-project-123",
+        "client_email": "bot@test-project-123.iam.gserviceaccount.com",
+    }), encoding="utf-8")
+
+    validator = EnvironmentValidator(project_root=temp_project, mode="dev")
+    monkeypatch.delenv("FIRESTORE_EMULATOR_HOST", raising=False)
+    monkeypatch.setenv("FIREBASE_CREDENTIALS_PATH", str(cred_file))
+    validator.check_firebase_configuration()
+
+    cred_result = next(r for r in validator.results if r.name == "FIREBASE_CREDENTIALS_PATH")
+    assert cred_result.status == CheckStatus.PASS
+    assert "test-project-123" in cred_result.message
+
+
+def test_firebase_no_config_fails_with_actionable_solution(temp_project, monkeypatch):
+    validator = EnvironmentValidator(project_root=temp_project, mode="dev")
+    monkeypatch.delenv("FIRESTORE_EMULATOR_HOST", raising=False)
+    monkeypatch.delenv("FIREBASE_CREDENTIALS_PATH", raising=False)
+    validator.check_firebase_configuration()
+
+    db_result = next(r for r in validator.results if r.name == "Database Setup")
+    assert db_result.status == CheckStatus.FAIL
+    assert db_result.remediation is not None
+    assert "FIRESTORE_EMULATOR_HOST" in db_result.remediation
+
+
+def test_cloud_tasks_dev_mode_vs_prod_mode(temp_project, monkeypatch):
+    monkeypatch.delenv("WEBHOOK_SECRET", raising=False)
+    monkeypatch.delenv("TASK_SECRET", raising=False)
+    monkeypatch.delenv("TASKS_QUEUE", raising=False)
+    monkeypatch.delenv("BROADCAST_QUEUE", raising=False)
+
+    # In dev mode, missing secrets are INFO
+    dev_validator = EnvironmentValidator(project_root=temp_project, mode="dev")
+    dev_validator.check_cloud_tasks_and_hardening()
+    assert not any(r.status == CheckStatus.FAIL for r in dev_validator.results)
+
+    # In prod mode, missing secrets are FAIL
+    prod_validator = EnvironmentValidator(project_root=temp_project, mode="prod")
+    prod_validator.check_cloud_tasks_and_hardening()
+    prod_failures = [r for r in prod_validator.results if r.status == CheckStatus.FAIL]
+    assert len(prod_failures) >= 4
+
+
+def test_cloud_tasks_secret_regex_validation(temp_project, monkeypatch):
+    monkeypatch.setenv("WEBHOOK_SECRET", "too-short")
+    monkeypatch.setenv("TASK_SECRET", "contains spaces and invalid chars!")
+    validator = EnvironmentValidator(project_root=temp_project, mode="dev")
+    validator.check_cloud_tasks_and_hardening()
+
+    failures = [r for r in validator.results if r.status == CheckStatus.FAIL]
+    assert len(failures) == 2
+    assert any("WEBHOOK_SECRET" in f.name for f in failures)
+    assert any("TASK_SECRET" in f.name for f in failures)
+
+
+def test_miniapp_url_validation(temp_project, monkeypatch):
+    monkeypatch.setenv("PUBLIC_BASE_URL", "http://insecure.test")
+
+    # In dev mode, http is accepted with warning/pass
+    dev_validator = EnvironmentValidator(project_root=temp_project, mode="dev")
+    dev_validator.check_miniapp_and_urls()
+    assert not dev_validator.has_failures
+
+    # In prod mode, http without https is FAIL
+    prod_validator = EnvironmentValidator(project_root=temp_project, mode="prod")
+    prod_validator.check_miniapp_and_urls()
+    assert prod_validator.has_failures
+    assert any("https://" in r.message for r in prod_validator.results if r.status == CheckStatus.FAIL)
+
+
+def test_main_cli_returns_expected_exit_codes(temp_project, monkeypatch):
+    monkeypatch.setenv("BOT_TOKEN", "123456:valid_test_token_123456789012345")
+    monkeypatch.setenv("FIRESTORE_EMULATOR_HOST", "127.0.0.1:8571")
+    monkeypatch.delenv("FIREBASE_CREDENTIALS_PATH", raising=False)
+
+    # Test dev mode with valid project -> 0
+    test_args = ["--project-root", str(temp_project), "--mode", "dev"]
+    with patch.object(sys, "argv", ["check_environment.py"] + test_args):
+        assert main() == 0
+
+    # Test prod mode on incomplete setup -> 1
+    test_prod_args = ["--project-root", str(temp_project), "--mode", "prod"]
+    with patch.object(sys, "argv", ["check_environment.py"] + test_prod_args):
+        assert main() == 1
+
+
+def test_json_output_mode(temp_project, monkeypatch, capsys):
+    monkeypatch.setenv("BOT_TOKEN", "123456:valid_test_token_123456789012345")
+    monkeypatch.setenv("FIRESTORE_EMULATOR_HOST", "127.0.0.1:8571")
+    monkeypatch.delenv("FIREBASE_CREDENTIALS_PATH", raising=False)
+    test_args = ["--project-root", str(temp_project), "--mode", "dev", "--json"]
+    with patch.object(sys, "argv", ["check_environment.py"] + test_args):
+        code = main()
+        assert code == 0
+
+    captured = capsys.readouterr()
+    payload = json.loads(captured.out)
+    assert payload["mode"] == "dev"
+    assert "checks" in payload
+    assert isinstance(payload["checks"], list)

--- a/tests/test_check_environment.py
+++ b/tests/test_check_environment.py
@@ -207,16 +207,63 @@ def test_cloud_tasks_dev_mode_vs_prod_mode(temp_project, monkeypatch):
     monkeypatch.delenv("TASKS_QUEUE", raising=False)
     monkeypatch.delenv("BROADCAST_QUEUE", raising=False)
 
-    # In dev mode, missing secrets are INFO
+    # In dev mode, missing secrets are INFO (isolated development)
     dev_validator = EnvironmentValidator(project_root=temp_project, mode="dev")
     dev_validator.check_cloud_tasks_and_hardening()
     assert not any(r.status == CheckStatus.FAIL for r in dev_validator.results)
+
+    # In api mode, missing secrets are FAIL (required for bot.py lifespan)
+    api_validator = EnvironmentValidator(project_root=temp_project, mode="api")
+    api_validator.check_cloud_tasks_and_hardening()
+    api_failures = [r for r in api_validator.results if r.status == CheckStatus.FAIL]
+    assert len(api_failures) == 4
 
     # In prod mode, missing secrets are FAIL
     prod_validator = EnvironmentValidator(project_root=temp_project, mode="prod")
     prod_validator.check_cloud_tasks_and_hardening()
     prod_failures = [r for r in prod_validator.results if r.status == CheckStatus.FAIL]
-    assert len(prod_failures) >= 4
+    assert len(prod_failures) == 4
+
+
+def test_api_mode_valid_configuration_passes(temp_project, monkeypatch):
+    monkeypatch.setenv("WEBHOOK_SECRET", "a" * 48)
+    monkeypatch.setenv("TASK_SECRET", "b" * 48)
+    monkeypatch.setenv("TASKS_QUEUE", "projects/p/locations/l/queues/tasks")
+    monkeypatch.setenv("BROADCAST_QUEUE", "projects/p/locations/l/queues/broadcast")
+    monkeypatch.setenv("PUBLIC_BASE_URL", "https://localhost:8000")
+
+    validator = EnvironmentValidator(project_root=temp_project, mode="api")
+    validator.check_cloud_tasks_and_hardening()
+    validator.check_miniapp_and_urls()
+    assert not validator.has_failures
+
+
+def test_prod_mode_without_dotenv_file_does_not_fail(temp_project):
+    env_file = temp_project / ".env"
+    if env_file.exists():
+        env_file.unlink()
+
+    validator = EnvironmentValidator(project_root=temp_project, mode="prod")
+    validator.check_dotenv_file()
+
+    dotenv_item = next(r for r in validator.results if r.name == ".env File")
+    assert dotenv_item.status == CheckStatus.INFO
+    assert "Nessun file .env presente" in dotenv_item.message
+    assert not validator.has_failures
+
+
+def test_prod_mode_firebase_adc_support(temp_project, monkeypatch):
+    monkeypatch.delenv("FIRESTORE_EMULATOR_HOST", raising=False)
+    monkeypatch.delenv("FIREBASE_CREDENTIALS_PATH", raising=False)
+    monkeypatch.delenv("GOOGLE_APPLICATION_CREDENTIALS", raising=False)
+
+    validator = EnvironmentValidator(project_root=temp_project, mode="prod")
+    validator.check_firebase_configuration()
+
+    db_item = next(r for r in validator.results if r.name == "Database Setup")
+    assert db_item.status == CheckStatus.INFO
+    assert "Application Default Credentials" in db_item.message
+    assert not validator.has_failures
 
 
 def test_cloud_tasks_secret_regex_validation(temp_project, monkeypatch):
@@ -234,10 +281,15 @@ def test_cloud_tasks_secret_regex_validation(temp_project, monkeypatch):
 def test_miniapp_url_validation(temp_project, monkeypatch):
     monkeypatch.setenv("PUBLIC_BASE_URL", "http://insecure.test")
 
-    # In dev mode, http is accepted with warning/pass
+    # In dev mode, http is accepted with warning
     dev_validator = EnvironmentValidator(project_root=temp_project, mode="dev")
     dev_validator.check_miniapp_and_urls()
     assert not dev_validator.has_failures
+
+    # In api mode, http without https is FAIL (task_queue.validate_configuration requires https://)
+    api_validator = EnvironmentValidator(project_root=temp_project, mode="api")
+    api_validator.check_miniapp_and_urls()
+    assert api_validator.has_failures
 
     # In prod mode, http without https is FAIL
     prod_validator = EnvironmentValidator(project_root=temp_project, mode="prod")

--- a/tests/test_dev_commands.py
+++ b/tests/test_dev_commands.py
@@ -6,6 +6,7 @@ from tools.dev import COMMANDS, main
 def test_commands_table_has_all_required_tasks():
     expected = {
         "check-env",
+        "check-api",
         "test",
         "test-cov",
         "test-node",
@@ -27,6 +28,7 @@ def test_help_command_returns_zero(capsys):
     captured = capsys.readouterr()
     assert "Comandi disponibili:" in captured.out
     assert "check-env" in captured.out
+    assert "check-api" in captured.out
     assert "emulator" in captured.out
 
 
@@ -39,15 +41,56 @@ def test_unknown_command_returns_one(capsys):
 def test_alias_resolution_dispatches_correctly():
     mock_env = MagicMock(return_value=0)
     mock_test = MagicMock(return_value=0)
-    with patch.dict(COMMANDS, {"check-env": (mock_env, "desc"), "test": (mock_test, "desc")}):
+    mock_api_check = MagicMock(return_value=0)
+    with patch.dict(COMMANDS, {
+        "check-env": (mock_env, "desc"),
+        "test": (mock_test, "desc"),
+        "check-api": (mock_api_check, "desc"),
+    }):
         assert main(["env", "--extra"]) == 0
         mock_env.assert_called_once_with(["--extra"])
 
         assert main(["tests", "-k", "unit"]) == 0
         mock_test.assert_called_once_with(["-k", "unit"])
 
+        assert main(["api-check"]) == 0
+        mock_api_check.assert_called_once_with([])
+
 
 def test_command_execution_failure_propagates_exit_code():
     with patch("tools.dev._run_cmd", return_value=42):
         code = main(["lint"])
         assert code == 42
+
+
+def test_api_command_blocks_when_lifespan_secrets_missing(monkeypatch, capsys):
+    monkeypatch.delenv("WEBHOOK_SECRET", raising=False)
+    monkeypatch.delenv("TASK_SECRET", raising=False)
+    monkeypatch.delenv("TASKS_QUEUE", raising=False)
+    monkeypatch.delenv("BROADCAST_QUEUE", raising=False)
+    monkeypatch.delenv("PUBLIC_BASE_URL", raising=False)
+
+    with patch("tools.dev._run_cmd") as mock_run:
+        code = main(["api"])
+        assert code == 1
+        mock_run.assert_not_called()
+
+    captured = capsys.readouterr()
+    assert "ERRORE AVVIO API" in captured.out
+    assert "check_environment --mode api" in captured.out
+
+
+def test_api_command_launches_when_configured(monkeypatch):
+    monkeypatch.setenv("WEBHOOK_SECRET", "a" * 48)
+    monkeypatch.setenv("TASK_SECRET", "b" * 48)
+    monkeypatch.setenv("TASKS_QUEUE", "projects/p/locations/l/queues/tasks")
+    monkeypatch.setenv("BROADCAST_QUEUE", "projects/p/locations/l/queues/broadcast")
+    monkeypatch.setenv("PUBLIC_BASE_URL", "https://localhost:8000")
+
+    with patch("tools.dev._run_cmd", return_value=0) as mock_run:
+        code = main(["api"])
+        assert code == 0
+        mock_run.assert_called_once()
+        cmd = mock_run.call_args[0][0]
+        assert "uvicorn" in cmd
+        assert "bot:app" in cmd

--- a/tests/test_dev_commands.py
+++ b/tests/test_dev_commands.py
@@ -1,0 +1,53 @@
+from unittest.mock import MagicMock, patch
+
+from tools.dev import COMMANDS, main
+
+
+def test_commands_table_has_all_required_tasks():
+    expected = {
+        "check-env",
+        "test",
+        "test-cov",
+        "test-node",
+        "lint",
+        "typecheck",
+        "syntax",
+        "dataset-check",
+        "check",
+        "api",
+        "admin",
+        "webapp",
+        "emulator",
+    }
+    assert expected.issubset(COMMANDS.keys())
+
+
+def test_help_command_returns_zero(capsys):
+    assert main(["--help"]) == 0
+    captured = capsys.readouterr()
+    assert "Comandi disponibili:" in captured.out
+    assert "check-env" in captured.out
+    assert "emulator" in captured.out
+
+
+def test_unknown_command_returns_one(capsys):
+    assert main(["unknown-task-xyz"]) == 1
+    captured = capsys.readouterr()
+    assert "comando sconosciuto 'unknown-task-xyz'" in captured.out
+
+
+def test_alias_resolution_dispatches_correctly():
+    mock_env = MagicMock(return_value=0)
+    mock_test = MagicMock(return_value=0)
+    with patch.dict(COMMANDS, {"check-env": (mock_env, "desc"), "test": (mock_test, "desc")}):
+        assert main(["env", "--extra"]) == 0
+        mock_env.assert_called_once_with(["--extra"])
+
+        assert main(["tests", "-k", "unit"]) == 0
+        mock_test.assert_called_once_with(["-k", "unit"])
+
+
+def test_command_execution_failure_propagates_exit_code():
+    with patch("tools.dev._run_cmd", return_value=42):
+        code = main(["lint"])
+        assert code == 42

--- a/tools/__init__.py
+++ b/tools/__init__.py
@@ -1,0 +1,1 @@
+"""Developer and operational tools for Guess the Player."""

--- a/tools/check_environment.py
+++ b/tools/check_environment.py
@@ -211,25 +211,40 @@ class EnvironmentValidator:
             )
 
     def check_dotenv_file(self) -> None:
-        """Verifica la presenza del file .env locale."""
+        """Verifica la presenza del file .env locale (opzionale sia in locale che in produzione)."""
         env_file = self.project_root / ".env"
         if env_file.exists():
-            self.add_result(
-                category="Configuration",
-                name=".env File",
-                status=CheckStatus.PASS,
-                message="File .env trovato nella root del progetto",
-            )
+            if self.mode in ("prod", "all"):
+                self.add_result(
+                    category="Configuration",
+                    name=".env File",
+                    status=CheckStatus.INFO,
+                    message="File .env trovato nella root (in produzione le variabili dell'ambiente di sistema hanno precedenza)",
+                )
+            else:
+                self.add_result(
+                    category="Configuration",
+                    name=".env File",
+                    status=CheckStatus.PASS,
+                    message="File .env trovato nella root del progetto",
+                )
         else:
-            status = CheckStatus.FAIL if self.mode == "prod" else CheckStatus.WARN
-            self.add_result(
-                category="Configuration",
-                name=".env File",
-                status=status,
-                message="File .env non trovato nella root del progetto",
-                remediation="Copia il file di esempio ed imposta le variabili d'ambiente necessarie:\n"
-                            "    copy .env.example .env  (Windows) oppure cp .env.example .env (Linux/WSL)",
-            )
+            if self.mode in ("prod", "all"):
+                self.add_result(
+                    category="Configuration",
+                    name=".env File",
+                    status=CheckStatus.INFO,
+                    message="Nessun file .env presente: la configurazione e' letta direttamente dall'ambiente di sistema (es. Cloud Run / Secret Manager)",
+                )
+            else:
+                self.add_result(
+                    category="Configuration",
+                    name=".env File",
+                    status=CheckStatus.INFO,
+                    message="File .env non trovato: le variabili vengono lette dall'ambiente di sistema o dai default di configurazione.",
+                    remediation="Copia il file di esempio ed imposta le variabili d'ambiente necessarie:\n"
+                                "    copy .env.example .env  (Windows) oppure cp .env.example .env (Linux/WSL)",
+                )
 
     def check_telegram_configuration(self) -> None:
         """Verifica la configurazione del bot Telegram (BOT_TOKEN, BOT_USERNAME, ADMIN_TELEGRAM_IDS)."""
@@ -240,7 +255,7 @@ class EnvironmentValidator:
                 name="BOT_TOKEN",
                 status=CheckStatus.FAIL,
                 message="BOT_TOKEN non e' impostato. Il bot e l'interfaccia admin non possono avviarsi.",
-                remediation="Richiedi un token a @BotFather su Telegram e aggiungilo al tuo .env:\n"
+                remediation="Richiedi un token a @BotFather su Telegram e aggiungilo al tuo .env o all'ambiente:\n"
                             "    BOT_TOKEN=123456789:ABCdefGhIJKlmNoPQRsTUVwxyZ",
             )
         else:
@@ -318,9 +333,10 @@ class EnvironmentValidator:
             )
 
     def check_firebase_configuration(self) -> None:
-        """Verifica la configurazione di Firebase / Firestore (Emulatore locale vs Credenziali di produzione)."""
+        """Verifica la configurazione di Firebase / Firestore (Emulatore locale vs Credenziali di produzione / ADC)."""
         emulator_host = os.getenv("FIRESTORE_EMULATOR_HOST", "").strip()
         credentials_path_str = os.getenv("FIREBASE_CREDENTIALS_PATH", "").strip()
+        google_app_creds = os.getenv("GOOGLE_APPLICATION_CREDENTIALS", "").strip()
 
         # In dev mode: e' sufficiente l'emulatore OPPURE le credenziali
         if emulator_host:
@@ -353,7 +369,7 @@ class EnvironmentValidator:
                         message=f"Emulatore Firestore attivo e raggiungibile su {emulator_host}",
                     )
                 else:
-                    msg_status = CheckStatus.WARN if self.mode == "dev" else CheckStatus.FAIL
+                    msg_status = CheckStatus.WARN if self.mode in ("dev", "api") else CheckStatus.FAIL
                     self.add_result(
                         category="Firebase",
                         name="Firestore Emulator",
@@ -370,13 +386,13 @@ class EnvironmentValidator:
                 cred_path = self.project_root / cred_path
 
             if not cred_path.exists():
-                if emulator_host and self.mode == "dev":
+                if emulator_host and self.mode in ("dev", "api"):
                     self.add_result(
                         category="Firebase",
                         name="FIREBASE_CREDENTIALS_PATH",
                         status=CheckStatus.INFO,
                         message=f"FIREBASE_CREDENTIALS_PATH impostato su '{cred_path.name}', ma il file non esiste. "
-                                "FIRESTORE_EMULATOR_HOST e' attivo per lo sviluppo locale.",
+                                "FIRESTORE_EMULATOR_HOST e' configurato per l'ambiente locale.",
                     )
                 else:
                     self.add_result(
@@ -384,7 +400,7 @@ class EnvironmentValidator:
                         name="FIREBASE_CREDENTIALS_PATH",
                         status=CheckStatus.FAIL,
                         message=f"File credenziali Firebase non trovato: '{cred_path}'",
-                        remediation="Verifica che FIREBASE_CREDENTIALS_PATH nel .env punti a un file JSON esistente "
+                        remediation="Verifica che FIREBASE_CREDENTIALS_PATH punti a un file JSON esistente "
                                     "(es. firebase-key.json).",
                     )
             else:
@@ -416,7 +432,26 @@ class EnvironmentValidator:
                     )
 
         if not emulator_host and not credentials_path_str:
-            if self.mode == "dev":
+            if google_app_creds:
+                cred_p = Path(google_app_creds)
+                if not cred_p.is_absolute():
+                    cred_p = self.project_root / cred_p
+                if cred_p.exists():
+                    self.add_result(
+                        category="Firebase",
+                        name="GOOGLE_APPLICATION_CREDENTIALS",
+                        status=CheckStatus.PASS,
+                        message=f"Credenziali ADC configurate tramite GOOGLE_APPLICATION_CREDENTIALS ({cred_p.name})",
+                    )
+                else:
+                    self.add_result(
+                        category="Firebase",
+                        name="GOOGLE_APPLICATION_CREDENTIALS",
+                        status=CheckStatus.FAIL,
+                        message=f"File GOOGLE_APPLICATION_CREDENTIALS non trovato: '{cred_p}'",
+                        remediation="Verifica il percorso del file di credenziali specificato.",
+                    )
+            elif self.mode in ("dev", "api"):
                 self.add_result(
                     category="Firebase",
                     name="Database Setup",
@@ -431,14 +466,21 @@ class EnvironmentValidator:
             else:
                 self.add_result(
                     category="Firebase",
-                    name="FIREBASE_CREDENTIALS_PATH",
-                    status=CheckStatus.FAIL,
-                    message="In produzione FIREBASE_CREDENTIALS_PATH e' obbligatorio (oppure credenziali ADC su Cloud Run).",
-                    remediation="Configura FIREBASE_CREDENTIALS_PATH con il percorso del file di credenziali.",
+                    name="Database Setup",
+                    status=CheckStatus.INFO,
+                    message="Nessun file FIREBASE_CREDENTIALS_PATH configurato: il runtime utilizzera' le "
+                            "Application Default Credentials (ADC) dell'ambiente (es. Cloud Run Service Account o Workload Identity).",
                 )
 
     def check_cloud_tasks_and_hardening(self) -> None:
-        """Verifica la configurazione di Cloud Tasks e dei segreti di sicurezza (lifespan e worker)."""
+        """Verifica la configurazione di Cloud Tasks e dei segreti di sicurezza (lifespan e worker).
+
+        Distingue:
+        - mode 'dev': sviluppo locale isolato (test, emulatore, preview webapp); le code e segreti sono opzionali (INFO).
+        - mode 'api': avvio del runtime completo bot.py (make api); WEBHOOK_SECRET, TASK_SECRET, code e PUBLIC_BASE_URL
+                      sono obbligatori per il lifespan FastAPI e task_queue.validate_configuration().
+        - mode 'prod': produzione su Cloud Run; formato rigoroso GCP e segreti obbligatori.
+        """
         webhook_secret = os.getenv("WEBHOOK_SECRET", "").strip()
         task_secret = os.getenv("TASK_SECRET", "").strip()
         tasks_queue = os.getenv("TASKS_QUEUE", "").strip()
@@ -448,21 +490,21 @@ class EnvironmentValidator:
         secret_regex = r"^[A-Za-z0-9_-]{32,256}$"
         queue_regex = r"^projects/[^/]+/locations/[^/]+/queues/[^/]+$"
 
-        # Modalità dev: le code Cloud Tasks sono opzionali a meno che non si voglia avviare bot.py con lifespan completo
+        requires_api_secrets = self.mode in ("api", "prod", "all")
         is_prod = self.mode in ("prod", "all")
 
-        # 1. WEBHOOK_SECRET
+        # 1. WEBHOOK_SECRET (richiesto da bot.py lifespan: re.fullmatch(r"[A-Za-z0-9_-]{32,256}", WEBHOOK_SECRET))
         if webhook_secret:
             if re.match(secret_regex, webhook_secret):
                 self.add_result(
-                    category="Security & Hardening",
+                    category="FastAPI Runtime (bot.py)",
                     name="WEBHOOK_SECRET",
                     status=CheckStatus.PASS,
                     message="WEBHOOK_SECRET valido (lunghezza adeguata, caratteri URL-safe)",
                 )
             else:
                 self.add_result(
-                    category="Security & Hardening",
+                    category="FastAPI Runtime (bot.py)",
                     name="WEBHOOK_SECRET",
                     status=CheckStatus.FAIL,
                     message="WEBHOOK_SECRET non valido: deve contenere da 32 a 256 caratteri URL-safe ([A-Za-z0-9_-]).",
@@ -470,27 +512,36 @@ class EnvironmentValidator:
                                 "    python -c \"import secrets; print(secrets.token_urlsafe(48))\"",
                 )
         else:
-            status = CheckStatus.FAIL if is_prod else CheckStatus.INFO
-            self.add_result(
-                category="Security & Hardening",
-                name="WEBHOOK_SECRET",
-                status=status,
-                message="WEBHOOK_SECRET non impostato (richiesto da bot.py per la registrazione e verifica del webhook).",
-                remediation="Genera il segreto con: python -c \"import secrets; print(secrets.token_urlsafe(48))\" e impostalo in .env.",
-            )
+            if requires_api_secrets:
+                self.add_result(
+                    category="FastAPI Runtime (bot.py)",
+                    name="WEBHOOK_SECRET",
+                    status=CheckStatus.FAIL,
+                    message="WEBHOOK_SECRET non impostato. Obbligatorio per il lifespan di bot.py (avvio server FastAPI).",
+                    remediation="Genera il segreto con: python -c \"import secrets; print(secrets.token_urlsafe(48))\" ed impostalo nel .env.",
+                )
+            else:
+                self.add_result(
+                    category="FastAPI Runtime (bot.py)",
+                    name="WEBHOOK_SECRET",
+                    status=CheckStatus.INFO,
+                    message="WEBHOOK_SECRET non impostato (opzionale per sviluppo isolato: test, emulatore, preview webapp; "
+                            "NECESSARIO per avviare il server bot.py con 'make api' o '--mode api').",
+                    remediation="Se intendi avviare bot.py (make api), genera un segreto di 32+ caratteri ed impostalo in .env.",
+                )
 
-        # 2. TASK_SECRET
+        # 2. TASK_SECRET (richiesto da task_queue.validate_configuration())
         if task_secret:
             if re.match(secret_regex, task_secret):
                 self.add_result(
-                    category="Security & Hardening",
+                    category="FastAPI Runtime (bot.py)",
                     name="TASK_SECRET",
                     status=CheckStatus.PASS,
                     message="TASK_SECRET valido (lunghezza adeguata, caratteri URL-safe)",
                 )
             else:
                 self.add_result(
-                    category="Security & Hardening",
+                    category="FastAPI Runtime (bot.py)",
                     name="TASK_SECRET",
                     status=CheckStatus.FAIL,
                     message="TASK_SECRET non valido: deve contenere da 32 a 256 caratteri URL-safe ([A-Za-z0-9_-]).",
@@ -498,42 +549,59 @@ class EnvironmentValidator:
                                 "    python -c \"import secrets; print(secrets.token_urlsafe(48))\"",
                 )
         else:
-            status = CheckStatus.FAIL if is_prod else CheckStatus.INFO
-            self.add_result(
-                category="Security & Hardening",
-                name="TASK_SECRET",
-                status=status,
-                message="TASK_SECRET non impostato (richiesto per proteggere gli endpoint worker Cloud Tasks).",
-                remediation="Genera il segreto con: python -c \"import secrets; print(secrets.token_urlsafe(48))\" e impostalo in .env.",
-            )
+            if requires_api_secrets:
+                self.add_result(
+                    category="FastAPI Runtime (bot.py)",
+                    name="TASK_SECRET",
+                    status=CheckStatus.FAIL,
+                    message="TASK_SECRET non impostato. Obbligatorio per services.task_queue.validate_configuration() al lifespan di bot.py.",
+                    remediation="Genera il segreto con: python -c \"import secrets; print(secrets.token_urlsafe(48))\" ed impostalo nel .env.",
+                )
+            else:
+                self.add_result(
+                    category="FastAPI Runtime (bot.py)",
+                    name="TASK_SECRET",
+                    status=CheckStatus.INFO,
+                    message="TASK_SECRET non impostato (opzionale per sviluppo isolato; "
+                            "NECESSARIO per avviare il server bot.py con 'make api' o '--mode api').",
+                    remediation="Se intendi avviare bot.py (make api), genera un segreto di 32+ caratteri ed impostalo in .env.",
+                )
 
         # 3. TASKS_QUEUE e BROADCAST_QUEUE
         for var_name, q_val in [("TASKS_QUEUE", tasks_queue), ("BROADCAST_QUEUE", broadcast_queue)]:
             if q_val:
-                if re.match(queue_regex, q_val):
+                if is_prod and not re.match(queue_regex, q_val):
                     self.add_result(
-                        category="Cloud Tasks",
+                        category="FastAPI Runtime (bot.py)",
                         name=var_name,
-                        status=CheckStatus.PASS,
-                        message=f"{var_name} configurata con percorso risorsa GCP valido",
+                        status=CheckStatus.FAIL,
+                        message=f"{var_name} non valida per produzione: '{q_val}'. Formato atteso: projects/<p>/locations/<l>/queues/<q>",
+                        remediation="Configura il percorso completo della coda come indicato in docs/runtime-hardening.md.",
                     )
                 else:
                     self.add_result(
-                        category="Cloud Tasks",
+                        category="FastAPI Runtime (bot.py)",
                         name=var_name,
-                        status=CheckStatus.FAIL,
-                        message=f"{var_name} non valida: '{q_val}'. Formato atteso: projects/<p>/locations/<l>/queues/<q>",
-                        remediation="Configura il percorso completo della coda come indicato in docs/runtime-hardening.md.",
+                        status=CheckStatus.PASS,
+                        message=f"{var_name} configurata: {q_val}",
                     )
             else:
-                status = CheckStatus.FAIL if is_prod else CheckStatus.INFO
-                self.add_result(
-                    category="Cloud Tasks",
-                    name=var_name,
-                    status=status,
-                    message=f"{var_name} non configurata (necessaria in produzione per le code Cloud Tasks).",
-                    remediation="Crea la coda su Cloud Tasks e imposta il percorso completo nel .env (vedi docs/runtime-hardening.md).",
-                )
+                if requires_api_secrets:
+                    self.add_result(
+                        category="FastAPI Runtime (bot.py)",
+                        name=var_name,
+                        status=CheckStatus.FAIL,
+                        message=f"{var_name} non configurata. Obbligatoria per services.task_queue.validate_configuration() al lifespan di bot.py.",
+                        remediation=f"Imposta {var_name} nel .env (in locale puo' essere un nome sintetico, es. projects/dev/locations/eu/queues/tasks).",
+                    )
+                else:
+                    self.add_result(
+                        category="FastAPI Runtime (bot.py)",
+                        name=var_name,
+                        status=CheckStatus.INFO,
+                        message=f"{var_name} non configurata (opzionale per sviluppo isolato; NECESSARIA per avviare bot.py con 'make api').",
+                        remediation=f"Per avviare 'make api', imposta {var_name} nel .env (vedi docs/local-development.md).",
+                    )
 
         # 4. GENERATION_SECRET
         if generation_secret:
@@ -556,42 +624,52 @@ class EnvironmentValidator:
     def check_miniapp_and_urls(self) -> None:
         """Verifica la configurazione degli URL pubblici e della Mini App Telegram."""
         public_url = os.getenv("PUBLIC_BASE_URL", "").strip().rstrip("/")
-        is_prod = self.mode in ("prod", "all")
+        requires_api = self.mode in ("api", "prod", "all")
 
         if public_url:
-            if is_prod and not public_url.startswith("https://"):
-                self.add_result(
-                    category="Mini App",
-                    name="PUBLIC_BASE_URL",
-                    status=CheckStatus.FAIL,
-                    message=f"PUBLIC_BASE_URL deve iniziare con 'https://' per la consegna dei task e la Mini App: '{public_url}'",
-                    remediation="Imposta un URL pubblico HTTPS (es. https://xxx.run.app).",
-                )
-            elif not public_url.startswith(("http://", "https://")):
-                self.add_result(
-                    category="Mini App",
-                    name="PUBLIC_BASE_URL",
-                    status=CheckStatus.WARN,
-                    message=f"PUBLIC_BASE_URL deve includere lo schema http:// o https://: '{public_url}'",
-                    remediation="Correggi PUBLIC_BASE_URL in .env aggiungendo https:// o http://.",
-                )
+            if not public_url.startswith("https://"):
+                # task_queue.validate_configuration() richiede rigorosamente https:// sia in dev che in prod
+                if requires_api:
+                    self.add_result(
+                        category="Mini App & URLs",
+                        name="PUBLIC_BASE_URL",
+                        status=CheckStatus.FAIL,
+                        message=f"PUBLIC_BASE_URL deve iniziare con 'https://' per task_queue e Mini App: '{public_url}'",
+                        remediation="Imposta un URL HTTPS (es. https://localhost:8000 per sviluppo o il tunnel ngrok/Cloudflare).",
+                    )
+                else:
+                    self.add_result(
+                        category="Mini App & URLs",
+                        name="PUBLIC_BASE_URL",
+                        status=CheckStatus.WARN,
+                        message=f"PUBLIC_BASE_URL non usa https:// ('{public_url}'). Funziona per preview statica, ma blocchera' bot.py.",
+                        remediation="Aggiungi https:// a PUBLIC_BASE_URL nel .env per consentire l'avvio del server bot.py.",
+                    )
             else:
                 self.add_result(
-                    category="Mini App",
+                    category="Mini App & URLs",
                     name="PUBLIC_BASE_URL",
                     status=CheckStatus.PASS,
                     message=f"PUBLIC_BASE_URL configurato: {public_url} (Mini App su {public_url}/app)",
                 )
         else:
-            status = CheckStatus.FAIL if is_prod else CheckStatus.WARN
-            self.add_result(
-                category="Mini App",
-                name="PUBLIC_BASE_URL",
-                status=status,
-                message="PUBLIC_BASE_URL non impostato: il bottone 'Play' della Mini App e i link ai duelli non compariranno.",
-                remediation="In locale puoi usare scripts/preview_webapp.py (porta 8888) senza configurare PUBLIC_BASE_URL.\n"
-                            "Per provare bot.py con la Mini App o webhook, usa un tunnel HTTPS (ngrok/localtunnel) ed imposta PUBLIC_BASE_URL.",
-            )
+            if requires_api:
+                self.add_result(
+                    category="Mini App & URLs",
+                    name="PUBLIC_BASE_URL",
+                    status=CheckStatus.FAIL,
+                    message="PUBLIC_BASE_URL non impostato. Obbligatorio con protocollo https:// per services.task_queue.validate_configuration() in bot.py.",
+                    remediation="Imposta un URL HTTPS in .env (es. PUBLIC_BASE_URL=https://localhost:8000 per test locali).",
+                )
+            else:
+                self.add_result(
+                    category="Mini App & URLs",
+                    name="PUBLIC_BASE_URL",
+                    status=CheckStatus.INFO,
+                    message="PUBLIC_BASE_URL non impostato: non necessario per lo sviluppo isolato o anteprima Mini App (make webapp); "
+                            "NECESSARIO (con https://) per avviare il server bot.py con 'make api'.",
+                    remediation="Per anteprima isolata usa 'make webapp' (porta 8888). Per avviare bot.py imposta PUBLIC_BASE_URL=https://...",
+                )
 
     def check_developer_tooling(self) -> None:
         """Verifica la presenza di strumenti e librerie di sviluppo utili (pytest, ruff, mypy, node, gcloud)."""
@@ -738,9 +816,13 @@ def main() -> int:
     )
     parser.add_argument(
         "--mode",
-        choices=["dev", "prod", "all"],
+        choices=["dev", "api", "prod", "all"],
         default="dev",
-        help="Ambiente target per la validazione (default: dev). 'prod' verifica anche chiavi e code Cloud Tasks.",
+        help="Ambiente target per la validazione:\n"
+             "  dev: sviluppo locale isolato (test, emulatore, preview webapp);\n"
+             "  api: avvio del server FastAPI bot.py con lifespan completo (make api);\n"
+             "  prod: deploy di produzione Cloud Run (verifica segreti e code GCP senza richiedere file .env);\n"
+             "  all: esegue tutti i controlli combinati.",
     )
     parser.add_argument(
         "--strict",

--- a/tools/check_environment.py
+++ b/tools/check_environment.py
@@ -1,0 +1,790 @@
+"""Validatore dell'ambiente di sviluppo e della configurazione di runtime.
+
+Verifica che i requisiti supportati dal codebase siano soddisfatti prima di
+avviare i servizi in locale o in produzione.
+
+Uso:
+    python -m tools.check_environment
+    python -m tools.check_environment --mode dev
+    python -m tools.check_environment --mode prod
+    python -m tools.check_environment --strict
+    python -m tools.check_environment --json
+"""
+import argparse
+import json
+import os
+import re
+import shutil
+import sys
+import urllib.error
+import urllib.request
+from dataclasses import asdict, dataclass
+from enum import Enum
+from pathlib import Path
+from typing import Any, Optional
+
+
+class CheckStatus(str, Enum):
+    PASS = "PASS"
+    WARN = "WARN"
+    FAIL = "FAIL"
+    INFO = "INFO"
+
+
+@dataclass
+class CheckItem:
+    category: str
+    name: str
+    status: CheckStatus
+    message: str
+    remediation: Optional[str] = None
+
+    def to_dict(self) -> dict[str, Any]:
+        data = asdict(self)
+        data["status"] = self.status.value
+        return data
+
+
+class EnvironmentValidator:
+    def __init__(self, project_root: Optional[Path] = None, mode: str = "dev", strict: bool = False):
+        self.project_root = (project_root or Path(__file__).resolve().parents[1]).resolve()
+        self.mode = mode.lower()
+        self.strict = strict
+        self.results: list[CheckItem] = []
+        self._load_dotenv_if_present()
+
+    def _load_dotenv_if_present(self) -> None:
+        """Carica il file .env se presente, senza dipendere strettamente da python-dotenv."""
+        env_file = self.project_root / ".env"
+        if not env_file.exists():
+            return
+        try:
+            from dotenv import load_dotenv
+            load_dotenv(env_file)
+        except ImportError:
+            # Fallback manuale minimale se python-dotenv non e' ancora installato
+            try:
+                with open(env_file, encoding="utf-8") as f:
+                    for line in f:
+                        line = line.strip()
+                        if not line or line.startswith("#") or "=" not in line:
+                            continue
+                        key, val = line.split("=", 1)
+                        key = key.strip()
+                        val = val.strip().strip("'\"")
+                        if key and key not in os.environ:
+                            os.environ[key] = val
+            except Exception:
+                pass
+
+    def add_result(self, category: str, name: str, status: CheckStatus, message: str,
+                   remediation: Optional[str] = None) -> None:
+        self.results.append(CheckItem(
+            category=category,
+            name=name,
+            status=status,
+            message=message,
+            remediation=remediation,
+        ))
+
+    def check_python_version(self) -> None:
+        """Verifica la versione minima di Python (3.11+ richiesta per asyncio.timeout e annotazioni)."""
+        current = sys.version_info
+        major, minor, micro = current[0], current[1], current[2]
+        version_str = f"{major}.{minor}.{micro}"
+        if (major, minor) >= (3, 11):
+            self.add_result(
+                category="Runtime",
+                name="Python Version",
+                status=CheckStatus.PASS,
+                message=f"Python {version_str} soddisfa il requisito minimo (>= 3.11)",
+            )
+        else:
+            self.add_result(
+                category="Runtime",
+                name="Python Version",
+                status=CheckStatus.FAIL,
+                message=f"Python {version_str} rilevato: il progetto richiede Python 3.11 o successivo "
+                        "(richiesto per asyncio.timeout in bot.py e target-version in pyproject.toml).",
+                remediation="Installa Python 3.11 o successivo e ricrea il virtual environment:\n"
+                            "    py -3.11 -m venv .venv\n"
+                            "    .\\.venv\\Scripts\\activate  (Windows) oppure source .venv/bin/activate (Linux/WSL)",
+            )
+
+    def check_datasets_and_files(self) -> None:
+        """Verifica la presenza e integrita sintattica dei dataset JSON e dei file core."""
+        datasets = [
+            ("data/players.json", "Dataset calciatori"),
+            ("data/config.json", "Configurazione di gioco (pesi e regole)"),
+            ("data/event_templates.json", "Template degli eventi"),
+            ("data/shop.json", "Catalogo del negozio e cosmetici"),
+        ]
+
+        for rel_path, desc in datasets:
+            file_path = self.project_root / rel_path
+            if not file_path.exists():
+                self.add_result(
+                    category="Datasets",
+                    name=rel_path,
+                    status=CheckStatus.FAIL,
+                    message=f"File {desc} non trovato: '{rel_path}'",
+                    remediation=f"Verifica che il repository contenga '{rel_path}' o ripristinalo da Git.",
+                )
+                continue
+
+            try:
+                with open(file_path, encoding="utf-8") as f:
+                    data = json.load(f)
+
+                # Controllo specifico per data/players.json
+                if rel_path == "data/players.json":
+                    players_list = data.get("players") if isinstance(data, dict) else (data if isinstance(data, list) else None)
+                    if not isinstance(players_list, list) or len(players_list) == 0:
+                        self.add_result(
+                            category="Datasets",
+                            name=rel_path,
+                            status=CheckStatus.FAIL,
+                            message=f"{desc} vuoto o non contiene una lista 'players'",
+                            remediation="Il file data/players.json deve contenere un dizionario con la chiave 'players' valida.",
+                        )
+                    else:
+                        first = players_list[0] if isinstance(players_list[0], dict) else {}
+                        required_fields = {"id", "full_name", "career"}
+                        missing_fields = required_fields - set(first.keys())
+                        if missing_fields:
+                            self.add_result(
+                                category="Datasets",
+                                name=rel_path,
+                                status=CheckStatus.FAIL,
+                                message=f"{desc} non ha i campi attesi (mancano in testa: {missing_fields})",
+                                remediation="Verifica l'integrita del file data/players.json con scripts/dataset_report.py.",
+                            )
+                        else:
+                            self.add_result(
+                                category="Datasets",
+                                name=rel_path,
+                                status=CheckStatus.PASS,
+                                message=f"{desc} valido ({len(players_list)} calciatori caricati)",
+                            )
+                else:
+                    self.add_result(
+                        category="Datasets",
+                        name=rel_path,
+                        status=CheckStatus.PASS,
+                        message=f"{desc} presente e JSON valido",
+                    )
+            except json.JSONDecodeError as err:
+                self.add_result(
+                    category="Datasets",
+                    name=rel_path,
+                    status=CheckStatus.FAIL,
+                    message=f"{desc} contiene JSON non valido: riga {err.lineno}, colonna {err.colno}",
+                    remediation=f"Correggi l'errore di sintassi JSON in '{rel_path}'.",
+                )
+
+        # Controllo asset statici WebApp
+        webapp_files = [
+            "webapp/index.html",
+            "webapp/client.js",
+            "webapp/strings.js",
+            "webapp/arena.js",
+            "webapp/referrals.js",
+            "webapp/legal.css",
+            "webapp/terms.html",
+            "webapp/privacy.html",
+        ]
+        missing_webapp = [f for f in webapp_files if not (self.project_root / f).exists()]
+        if missing_webapp:
+            self.add_result(
+                category="Mini App",
+                name="Static Files",
+                status=CheckStatus.FAIL,
+                message=f"File statici della Mini App mancanti: {', '.join(missing_webapp)}",
+                remediation="Ripristina i file della cartella webapp/ da git.",
+            )
+        else:
+            self.add_result(
+                category="Mini App",
+                name="Static Files",
+                status=CheckStatus.PASS,
+                message="Tutti i file statici della Mini App sono presenti in webapp/",
+            )
+
+    def check_dotenv_file(self) -> None:
+        """Verifica la presenza del file .env locale."""
+        env_file = self.project_root / ".env"
+        if env_file.exists():
+            self.add_result(
+                category="Configuration",
+                name=".env File",
+                status=CheckStatus.PASS,
+                message="File .env trovato nella root del progetto",
+            )
+        else:
+            status = CheckStatus.FAIL if self.mode == "prod" else CheckStatus.WARN
+            self.add_result(
+                category="Configuration",
+                name=".env File",
+                status=status,
+                message="File .env non trovato nella root del progetto",
+                remediation="Copia il file di esempio ed imposta le variabili d'ambiente necessarie:\n"
+                            "    copy .env.example .env  (Windows) oppure cp .env.example .env (Linux/WSL)",
+            )
+
+    def check_telegram_configuration(self) -> None:
+        """Verifica la configurazione del bot Telegram (BOT_TOKEN, BOT_USERNAME, ADMIN_TELEGRAM_IDS)."""
+        bot_token = os.getenv("BOT_TOKEN", "").strip()
+        if not bot_token:
+            self.add_result(
+                category="Telegram",
+                name="BOT_TOKEN",
+                status=CheckStatus.FAIL,
+                message="BOT_TOKEN non e' impostato. Il bot e l'interfaccia admin non possono avviarsi.",
+                remediation="Richiedi un token a @BotFather su Telegram e aggiungilo al tuo .env:\n"
+                            "    BOT_TOKEN=123456789:ABCdefGhIJKlmNoPQRsTUVwxyZ",
+            )
+        else:
+            # Controllo formato generico token Telegram: <id_numerico>:<stringa_alfanumerica>
+            token_pattern = r"^\d{6,15}:[A-Za-z0-9_-]{30,}$"
+            # Supportiamo anche token di test sintetici in locale se esplicitamente impostati
+            if re.match(token_pattern, bot_token) or bot_token.startswith("test-") or bot_token == "preview-bot-token":
+                self.add_result(
+                    category="Telegram",
+                    name="BOT_TOKEN",
+                    status=CheckStatus.PASS,
+                    message="BOT_TOKEN configurato con formato valido",
+                )
+            else:
+                self.add_result(
+                    category="Telegram",
+                    name="BOT_TOKEN",
+                    status=CheckStatus.WARN,
+                    message="BOT_TOKEN non rispetta il consueto formato Telegram (<id_numerico>:<token>)",
+                    remediation="Verifica che BOT_TOKEN sia stato copiato interamente da @BotFather senza spazi.",
+                )
+
+        bot_username = os.getenv("BOT_USERNAME", "").strip()
+        if not bot_username:
+            self.add_result(
+                category="Telegram",
+                name="BOT_USERNAME",
+                status=CheckStatus.WARN,
+                message="BOT_USERNAME non impostato: i bottoni di condivisione risultato e i link d'invito non compariranno.",
+                remediation="Imposta lo username del bot senza @ in .env (es. BOT_USERNAME=guess_the_player_bot).",
+            )
+        else:
+            if bot_username.startswith("@"):
+                self.add_result(
+                    category="Telegram",
+                    name="BOT_USERNAME",
+                    status=CheckStatus.WARN,
+                    message="BOT_USERNAME inizia con '@': deve essere impostato senza la chiocciola.",
+                    remediation=f"Rimuovi '@' nel .env: BOT_USERNAME={bot_username.lstrip('@')}",
+                )
+            else:
+                self.add_result(
+                    category="Telegram",
+                    name="BOT_USERNAME",
+                    status=CheckStatus.PASS,
+                    message=f"BOT_USERNAME configurato: @{bot_username}",
+                )
+
+        admin_ids_raw = os.getenv("ADMIN_TELEGRAM_IDS", "").strip()
+        if admin_ids_raw:
+            parts = [x.strip() for x in admin_ids_raw.split(",") if x.strip()]
+            invalid_ids = [x for x in parts if not x.isdigit()]
+            if invalid_ids:
+                self.add_result(
+                    category="Telegram",
+                    name="ADMIN_TELEGRAM_IDS",
+                    status=CheckStatus.WARN,
+                    message=f"ADMIN_TELEGRAM_IDS contiene valori non numerici: {invalid_ids}",
+                    remediation="ADMIN_TELEGRAM_IDS deve essere un elenco di ID numerici Telegram separati da virgola.",
+                )
+            else:
+                self.add_result(
+                    category="Telegram",
+                    name="ADMIN_TELEGRAM_IDS",
+                    status=CheckStatus.PASS,
+                    message=f"ADMIN_TELEGRAM_IDS configurato ({len(parts)} amministratori abilitati)",
+                )
+        else:
+            self.add_result(
+                category="Telegram",
+                name="ADMIN_TELEGRAM_IDS",
+                status=CheckStatus.INFO,
+                message="ADMIN_TELEGRAM_IDS non impostato: nessun utente abilitato ai comandi /admin_*",
+                remediation="Se desideri usare i comandi admin su Telegram, aggiungi il tuo ID Telegram a ADMIN_TELEGRAM_IDS nel .env.",
+            )
+
+    def check_firebase_configuration(self) -> None:
+        """Verifica la configurazione di Firebase / Firestore (Emulatore locale vs Credenziali di produzione)."""
+        emulator_host = os.getenv("FIRESTORE_EMULATOR_HOST", "").strip()
+        credentials_path_str = os.getenv("FIREBASE_CREDENTIALS_PATH", "").strip()
+
+        # In dev mode: e' sufficiente l'emulatore OPPURE le credenziali
+        if emulator_host:
+            # Controllo formato host:porta
+            host_pattern = r"^[a-zA-Z0-9.-]+:\d+$"
+            if not re.match(host_pattern, emulator_host):
+                self.add_result(
+                    category="Firebase",
+                    name="FIRESTORE_EMULATOR_HOST",
+                    status=CheckStatus.FAIL,
+                    message=f"Formato non valido per FIRESTORE_EMULATOR_HOST: '{emulator_host}' (atteso host:porta)",
+                    remediation="Imposta un host valido, es. FIRESTORE_EMULATOR_HOST=127.0.0.1:8571",
+                )
+            else:
+                # Prova di connettività HTTP verso l'emulatore
+                reachable = False
+                try:
+                    url = f"http://{emulator_host}/"
+                    req = urllib.request.Request(url, method="GET")
+                    with urllib.request.urlopen(req, timeout=1.0) as resp:
+                        reachable = resp.status in (200, 404)
+                except Exception:
+                    reachable = False
+
+                if reachable:
+                    self.add_result(
+                        category="Firebase",
+                        name="Firestore Emulator",
+                        status=CheckStatus.PASS,
+                        message=f"Emulatore Firestore attivo e raggiungibile su {emulator_host}",
+                    )
+                else:
+                    msg_status = CheckStatus.WARN if self.mode == "dev" else CheckStatus.FAIL
+                    self.add_result(
+                        category="Firebase",
+                        name="Firestore Emulator",
+                        status=msg_status,
+                        message=f"FIRESTORE_EMULATOR_HOST impostato su {emulator_host}, ma l'emulatore non risponde.",
+                        remediation="Avvia l'emulatore Firestore in un terminale separato con:\n"
+                                    "    gcloud emulators firestore start --host-port=" + emulator_host + "\n"
+                                    "oppure con il comando di sviluppo: make emulator / python -m tools.dev emulator",
+                    )
+
+        if credentials_path_str:
+            cred_path = Path(credentials_path_str)
+            if not cred_path.is_absolute():
+                cred_path = self.project_root / cred_path
+
+            if not cred_path.exists():
+                if emulator_host and self.mode == "dev":
+                    self.add_result(
+                        category="Firebase",
+                        name="FIREBASE_CREDENTIALS_PATH",
+                        status=CheckStatus.INFO,
+                        message=f"FIREBASE_CREDENTIALS_PATH impostato su '{cred_path.name}', ma il file non esiste. "
+                                "FIRESTORE_EMULATOR_HOST e' attivo per lo sviluppo locale.",
+                    )
+                else:
+                    self.add_result(
+                        category="Firebase",
+                        name="FIREBASE_CREDENTIALS_PATH",
+                        status=CheckStatus.FAIL,
+                        message=f"File credenziali Firebase non trovato: '{cred_path}'",
+                        remediation="Verifica che FIREBASE_CREDENTIALS_PATH nel .env punti a un file JSON esistente "
+                                    "(es. firebase-key.json).",
+                    )
+            else:
+                try:
+                    with open(cred_path, encoding="utf-8") as f:
+                        key_data = json.load(f)
+                    if isinstance(key_data, dict) and ("project_id" in key_data or "client_email" in key_data):
+                        self.add_result(
+                            category="Firebase",
+                            name="FIREBASE_CREDENTIALS_PATH",
+                            status=CheckStatus.PASS,
+                            message=f"File credenziali Firebase valido: {cred_path.name} (Project: {key_data.get('project_id', 'n/d')})",
+                        )
+                    else:
+                        self.add_result(
+                            category="Firebase",
+                            name="FIREBASE_CREDENTIALS_PATH",
+                            status=CheckStatus.WARN,
+                            message=f"Il file '{cred_path.name}' non sembra una chiave di servizio valida.",
+                            remediation="Scarica una chiave di servizio JSON valida dalla console Firebase/Google Cloud.",
+                        )
+                except Exception as err:
+                    self.add_result(
+                        category="Firebase",
+                        name="FIREBASE_CREDENTIALS_PATH",
+                        status=CheckStatus.FAIL,
+                        message=f"Errore nella lettura del file credenziali Firebase: {err}",
+                        remediation=f"Verifica che '{cred_path}' sia un file JSON valido.",
+                    )
+
+        if not emulator_host and not credentials_path_str:
+            if self.mode == "dev":
+                self.add_result(
+                    category="Firebase",
+                    name="Database Setup",
+                    status=CheckStatus.FAIL,
+                    message="Nessuna configurazione Firestore rilevata (ne' FIRESTORE_EMULATOR_HOST ne' FIREBASE_CREDENTIALS_PATH).",
+                    remediation="Per lo sviluppo locale, scegli una delle due opzioni:\n"
+                                "1. (Consigliato) Avvia l'emulatore locale ed imposta nel .env o nel terminale:\n"
+                                "       FIRESTORE_EMULATOR_HOST=127.0.0.1:8571\n"
+                                "2. Oppure scarica la chiave del service account da Firebase e impostala nel .env:\n"
+                                "       FIREBASE_CREDENTIALS_PATH=firebase-key.json",
+                )
+            else:
+                self.add_result(
+                    category="Firebase",
+                    name="FIREBASE_CREDENTIALS_PATH",
+                    status=CheckStatus.FAIL,
+                    message="In produzione FIREBASE_CREDENTIALS_PATH e' obbligatorio (oppure credenziali ADC su Cloud Run).",
+                    remediation="Configura FIREBASE_CREDENTIALS_PATH con il percorso del file di credenziali.",
+                )
+
+    def check_cloud_tasks_and_hardening(self) -> None:
+        """Verifica la configurazione di Cloud Tasks e dei segreti di sicurezza (lifespan e worker)."""
+        webhook_secret = os.getenv("WEBHOOK_SECRET", "").strip()
+        task_secret = os.getenv("TASK_SECRET", "").strip()
+        tasks_queue = os.getenv("TASKS_QUEUE", "").strip()
+        broadcast_queue = os.getenv("BROADCAST_QUEUE", "").strip()
+        generation_secret = os.getenv("GENERATION_SECRET", "").strip()
+
+        secret_regex = r"^[A-Za-z0-9_-]{32,256}$"
+        queue_regex = r"^projects/[^/]+/locations/[^/]+/queues/[^/]+$"
+
+        # Modalità dev: le code Cloud Tasks sono opzionali a meno che non si voglia avviare bot.py con lifespan completo
+        is_prod = self.mode in ("prod", "all")
+
+        # 1. WEBHOOK_SECRET
+        if webhook_secret:
+            if re.match(secret_regex, webhook_secret):
+                self.add_result(
+                    category="Security & Hardening",
+                    name="WEBHOOK_SECRET",
+                    status=CheckStatus.PASS,
+                    message="WEBHOOK_SECRET valido (lunghezza adeguata, caratteri URL-safe)",
+                )
+            else:
+                self.add_result(
+                    category="Security & Hardening",
+                    name="WEBHOOK_SECRET",
+                    status=CheckStatus.FAIL,
+                    message="WEBHOOK_SECRET non valido: deve contenere da 32 a 256 caratteri URL-safe ([A-Za-z0-9_-]).",
+                    remediation="Genera un segreto sicuro con:\n"
+                                "    python -c \"import secrets; print(secrets.token_urlsafe(48))\"",
+                )
+        else:
+            status = CheckStatus.FAIL if is_prod else CheckStatus.INFO
+            self.add_result(
+                category="Security & Hardening",
+                name="WEBHOOK_SECRET",
+                status=status,
+                message="WEBHOOK_SECRET non impostato (richiesto da bot.py per la registrazione e verifica del webhook).",
+                remediation="Genera il segreto con: python -c \"import secrets; print(secrets.token_urlsafe(48))\" e impostalo in .env.",
+            )
+
+        # 2. TASK_SECRET
+        if task_secret:
+            if re.match(secret_regex, task_secret):
+                self.add_result(
+                    category="Security & Hardening",
+                    name="TASK_SECRET",
+                    status=CheckStatus.PASS,
+                    message="TASK_SECRET valido (lunghezza adeguata, caratteri URL-safe)",
+                )
+            else:
+                self.add_result(
+                    category="Security & Hardening",
+                    name="TASK_SECRET",
+                    status=CheckStatus.FAIL,
+                    message="TASK_SECRET non valido: deve contenere da 32 a 256 caratteri URL-safe ([A-Za-z0-9_-]).",
+                    remediation="Genera un segreto sicuro con:\n"
+                                "    python -c \"import secrets; print(secrets.token_urlsafe(48))\"",
+                )
+        else:
+            status = CheckStatus.FAIL if is_prod else CheckStatus.INFO
+            self.add_result(
+                category="Security & Hardening",
+                name="TASK_SECRET",
+                status=status,
+                message="TASK_SECRET non impostato (richiesto per proteggere gli endpoint worker Cloud Tasks).",
+                remediation="Genera il segreto con: python -c \"import secrets; print(secrets.token_urlsafe(48))\" e impostalo in .env.",
+            )
+
+        # 3. TASKS_QUEUE e BROADCAST_QUEUE
+        for var_name, q_val in [("TASKS_QUEUE", tasks_queue), ("BROADCAST_QUEUE", broadcast_queue)]:
+            if q_val:
+                if re.match(queue_regex, q_val):
+                    self.add_result(
+                        category="Cloud Tasks",
+                        name=var_name,
+                        status=CheckStatus.PASS,
+                        message=f"{var_name} configurata con percorso risorsa GCP valido",
+                    )
+                else:
+                    self.add_result(
+                        category="Cloud Tasks",
+                        name=var_name,
+                        status=CheckStatus.FAIL,
+                        message=f"{var_name} non valida: '{q_val}'. Formato atteso: projects/<p>/locations/<l>/queues/<q>",
+                        remediation="Configura il percorso completo della coda come indicato in docs/runtime-hardening.md.",
+                    )
+            else:
+                status = CheckStatus.FAIL if is_prod else CheckStatus.INFO
+                self.add_result(
+                    category="Cloud Tasks",
+                    name=var_name,
+                    status=status,
+                    message=f"{var_name} non configurata (necessaria in produzione per le code Cloud Tasks).",
+                    remediation="Crea la coda su Cloud Tasks e imposta il percorso completo nel .env (vedi docs/runtime-hardening.md).",
+                )
+
+        # 4. GENERATION_SECRET
+        if generation_secret:
+            self.add_result(
+                category="Security & Hardening",
+                name="GENERATION_SECRET",
+                status=CheckStatus.PASS,
+                message="GENERATION_SECRET configurato per il job di generazione notturna",
+            )
+        else:
+            status = CheckStatus.WARN if is_prod else CheckStatus.INFO
+            self.add_result(
+                category="Security & Hardening",
+                name="GENERATION_SECRET",
+                status=status,
+                message="GENERATION_SECRET non impostato: la chiamata a /internal/daily-job non sara' autorizzata.",
+                remediation="Imposta GENERATION_SECRET con una stringa casuale condivisa con Cloud Scheduler.",
+            )
+
+    def check_miniapp_and_urls(self) -> None:
+        """Verifica la configurazione degli URL pubblici e della Mini App Telegram."""
+        public_url = os.getenv("PUBLIC_BASE_URL", "").strip().rstrip("/")
+        is_prod = self.mode in ("prod", "all")
+
+        if public_url:
+            if is_prod and not public_url.startswith("https://"):
+                self.add_result(
+                    category="Mini App",
+                    name="PUBLIC_BASE_URL",
+                    status=CheckStatus.FAIL,
+                    message=f"PUBLIC_BASE_URL deve iniziare con 'https://' per la consegna dei task e la Mini App: '{public_url}'",
+                    remediation="Imposta un URL pubblico HTTPS (es. https://xxx.run.app).",
+                )
+            elif not public_url.startswith(("http://", "https://")):
+                self.add_result(
+                    category="Mini App",
+                    name="PUBLIC_BASE_URL",
+                    status=CheckStatus.WARN,
+                    message=f"PUBLIC_BASE_URL deve includere lo schema http:// o https://: '{public_url}'",
+                    remediation="Correggi PUBLIC_BASE_URL in .env aggiungendo https:// o http://.",
+                )
+            else:
+                self.add_result(
+                    category="Mini App",
+                    name="PUBLIC_BASE_URL",
+                    status=CheckStatus.PASS,
+                    message=f"PUBLIC_BASE_URL configurato: {public_url} (Mini App su {public_url}/app)",
+                )
+        else:
+            status = CheckStatus.FAIL if is_prod else CheckStatus.WARN
+            self.add_result(
+                category="Mini App",
+                name="PUBLIC_BASE_URL",
+                status=status,
+                message="PUBLIC_BASE_URL non impostato: il bottone 'Play' della Mini App e i link ai duelli non compariranno.",
+                remediation="In locale puoi usare scripts/preview_webapp.py (porta 8888) senza configurare PUBLIC_BASE_URL.\n"
+                            "Per provare bot.py con la Mini App o webhook, usa un tunnel HTTPS (ngrok/localtunnel) ed imposta PUBLIC_BASE_URL.",
+            )
+
+    def check_developer_tooling(self) -> None:
+        """Verifica la presenza di strumenti e librerie di sviluppo utili (pytest, ruff, mypy, node, gcloud)."""
+        # Dipendenze Python
+        packages = [
+            ("pytest", "pytest (suite di test)"),
+            ("ruff", "ruff (linter e formatter)"),
+            ("mypy", "mypy (type checker)"),
+            ("streamlit", "streamlit (dashboard admin locale)"),
+            ("fastapi", "fastapi (server API)"),
+            ("uvicorn", "uvicorn (server ASGI)"),
+            ("telegram", "python-telegram-bot (interfaccia bot)"),
+        ]
+        missing_pkgs = []
+        for mod_name, label in packages:
+            try:
+                __import__(mod_name)
+            except ImportError:
+                missing_pkgs.append(label)
+
+        if missing_pkgs:
+            self.add_result(
+                category="Tooling",
+                name="Python Packages",
+                status=CheckStatus.WARN,
+                message=f"Alcuni pacchetti utili non sono installati: {', '.join(missing_pkgs)}",
+                remediation="Installa le dipendenze di sviluppo con:\n    pip install -r requirements-dev.txt",
+            )
+        else:
+            self.add_result(
+                category="Tooling",
+                name="Python Packages",
+                status=CheckStatus.PASS,
+                message="Tutti i pacchetti Python core e dev sono installati",
+            )
+
+        # Binari esterni: node, gcloud, java
+        binaries = [
+            ("node", "Node.js (necessario per node --test tests/client.test.cjs)"),
+            ("gcloud", "Google Cloud SDK (necessario per l'emulatore Firestore)"),
+            ("java", "Java JRE/JDK (necessario per l'emulatore Firestore)"),
+        ]
+        for bin_name, label in binaries:
+            found = shutil.which(bin_name)
+            if found:
+                self.add_result(
+                    category="Tooling",
+                    name=f"CLI {bin_name}",
+                    status=CheckStatus.PASS,
+                    message=f"{label} disponibile nel PATH ({found})",
+                )
+            else:
+                self.add_result(
+                    category="Tooling",
+                    name=f"CLI {bin_name}",
+                    status=CheckStatus.INFO,
+                    message=f"{label} non trovato nel PATH",
+                    remediation=f"Se intendi eseguire {bin_name}, assicurati che sia installato e aggiunto al PATH.",
+                )
+
+    def run_all(self) -> list[CheckItem]:
+        """Esegue tutti i controlli previsti per la modalita' configurata."""
+        self.results.clear()
+        self.check_python_version()
+        self.check_datasets_and_files()
+        self.check_dotenv_file()
+        self.check_telegram_configuration()
+        self.check_firebase_configuration()
+        self.check_cloud_tasks_and_hardening()
+        self.check_miniapp_and_urls()
+        self.check_developer_tooling()
+        return self.results
+
+    @property
+    def has_failures(self) -> bool:
+        if self.strict:
+            return any(r.status in (CheckStatus.FAIL, CheckStatus.WARN) for r in self.results)
+        return any(r.status == CheckStatus.FAIL for r in self.results)
+
+    def print_report(self, quiet: bool = False) -> None:
+        """Stampa a terminale un report formattato e chiaro dei controlli eseguiti."""
+        # Selettore simboli/colori
+        icons = {
+            CheckStatus.PASS: "[OK]  ",
+            CheckStatus.WARN: "[WARN]",
+            CheckStatus.FAIL: "[FAIL]",
+            CheckStatus.INFO: "[INFO]",
+        }
+
+        # Raggruppa per categoria
+        categories: dict[str, list[CheckItem]] = {}
+        for item in self.results:
+            categories.setdefault(item.category, []).append(item)
+
+        print("\n============================================================")
+        print(" Guess the Player - Environment & Configuration Validator")
+        print(f" Modalita': {self.mode.upper()} | Root: {self.project_root}")
+        print("============================================================\n")
+
+        failures: list[CheckItem] = []
+        warnings: list[CheckItem] = []
+
+        for cat, items in categories.items():
+            if quiet and all(i.status == CheckStatus.PASS for i in items):
+                continue
+            print(f"--- {cat} ---")
+            for item in items:
+                if quiet and item.status == CheckStatus.PASS:
+                    continue
+                tag = icons[item.status]
+                print(f"  {tag} {item.name}: {item.message}")
+                if item.status == CheckStatus.FAIL:
+                    failures.append(item)
+                elif item.status == CheckStatus.WARN:
+                    warnings.append(item)
+            print()
+
+        pass_count = sum(1 for r in self.results if r.status == CheckStatus.PASS)
+        warn_count = sum(1 for r in self.results if r.status == CheckStatus.WARN)
+        fail_count = sum(1 for r in self.results if r.status == CheckStatus.FAIL)
+        info_count = sum(1 for r in self.results if r.status == CheckStatus.INFO)
+
+        print("------------------------------------------------------------")
+        print(f"Riepilogo: {pass_count} OK, {warn_count} avvisi, {fail_count} errori, {info_count} note.")
+        print("------------------------------------------------------------")
+
+        # Sezione remediations per problemi bloccanti o avvisi
+        action_items = failures + (warnings if self.strict else [])
+        if action_items:
+            print("\n>>> AZIONI RICHIESTE PER RISOLVERE I PROBLEMI RILEVATI <<<\n")
+            for i, item in enumerate(action_items, 1):
+                print(f"{i}. [{item.category}] {item.name}")
+                print(f"   Problema: {item.message}")
+                if item.remediation:
+                    print("   Soluzione:\n     " + "\n     ".join(item.remediation.split("\n")))
+                print()
+        elif not quiet:
+            print("\n Configurazione coerente per la modalita' selezionata!\n")
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(
+        description="Verifica l'ambiente di sviluppo e la configurazione per Guess the Player."
+    )
+    parser.add_argument(
+        "--mode",
+        choices=["dev", "prod", "all"],
+        default="dev",
+        help="Ambiente target per la validazione (default: dev). 'prod' verifica anche chiavi e code Cloud Tasks.",
+    )
+    parser.add_argument(
+        "--strict",
+        action="store_true",
+        help="Modalita' rigorosa: considera i WARN come errori (exit code 1).",
+    )
+    parser.add_argument(
+        "--json",
+        action="store_true",
+        help="Stampa l'esito dei controlli in formato JSON per script e automazioni.",
+    )
+    parser.add_argument(
+        "--quiet",
+        action="store_true",
+        help="Mostra solo errori e avvisi, nascondendo i controlli superati.",
+    )
+    parser.add_argument(
+        "--project-root",
+        type=Path,
+        default=None,
+        help="Percorso della root del progetto (opzionale).",
+    )
+    args = parser.parse_args()
+
+    validator = EnvironmentValidator(
+        project_root=args.project_root,
+        mode=args.mode,
+        strict=args.strict,
+    )
+    validator.run_all()
+
+    if args.json:
+        payload = {
+            "mode": args.mode,
+            "strict": args.strict,
+            "has_failures": validator.has_failures,
+            "checks": [r.to_dict() for r in validator.results],
+        }
+        print(json.dumps(payload, indent=2))
+    else:
+        validator.print_report(quiet=args.quiet)
+
+    return 1 if validator.has_failures else 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/tools/dev.py
+++ b/tools/dev.py
@@ -1,0 +1,238 @@
+"""Runner di comandi locali multipiattaforma per Guess the Player.
+
+Fornisce un punto di ingresso unico per avviare servizi di sviluppo, test,
+linting, typechecking e controlli di integrita' del dataset.
+
+Funziona in modo identico su Windows, WSL, Linux e macOS senza richiedere
+dipendenze esterne o l'installazione di GNU make.
+
+Uso:
+    python -m tools.dev <comando> [argomenti opzionali...]
+    python -m tools.dev --help
+"""
+import os
+import subprocess
+import sys
+from pathlib import Path
+from typing import Callable, Optional
+
+ROOT_DIR = Path(__file__).resolve().parents[1]
+
+
+def _run_cmd(cmd: list[str], *, env: Optional[dict[str, str]] = None, cwd: Optional[Path] = None) -> int:
+    """Esegue un comando di sistema e ne restituisce il codice di uscita."""
+    working_dir = cwd or ROOT_DIR
+    cmd_str = " ".join(cmd)
+    print(f">> Eseguo: {cmd_str} (in {working_dir})")
+    run_env = os.environ.copy()
+    if env:
+        run_env.update(env)
+    try:
+        proc = subprocess.run(cmd, cwd=str(working_dir), env=run_env)
+        return proc.returncode
+    except FileNotFoundError as err:
+        print(f"Errore: eseguibile non trovato per '{cmd[0]}': {err}")
+        return 1
+    except KeyboardInterrupt:
+        print("\nProcesso interrotto dall'utente.")
+        return 130
+
+
+# ---------------------------------------------------------------------------
+# Comandi supportati
+# ---------------------------------------------------------------------------
+
+
+def cmd_check_env(extra_args: list[str]) -> int:
+    """Verifica l'ambiente e la configurazione con tools.check_environment."""
+    cmd = [sys.executable, "-m", "tools.check_environment"] + extra_args
+    return _run_cmd(cmd)
+
+
+def cmd_test(extra_args: list[str]) -> int:
+    """Esegue la suite di unit test con pytest."""
+    cmd = [sys.executable, "-m", "pytest", "-q"] + extra_args
+    return _run_cmd(cmd)
+
+
+def cmd_test_cov(extra_args: list[str]) -> int:
+    """Esegue i test con report di copertura (coverage)."""
+    cmd = [
+        sys.executable,
+        "-m",
+        "pytest",
+        "-q",
+        "--cov=services",
+        "--cov=handlers",
+        "--cov-report=term-missing",
+    ] + extra_args
+    return _run_cmd(cmd)
+
+
+def cmd_test_node(extra_args: list[str]) -> int:
+    """Esegue i test client per la Mini App con Node.js."""
+    cmd = ["node", "--test", "tests/client.test.cjs"] + extra_args
+    return _run_cmd(cmd)
+
+
+def cmd_lint(extra_args: list[str]) -> int:
+    """Esegue il linter ruff su tutto il repository."""
+    cmd = [sys.executable, "-m", "ruff", "check", "."] + extra_args
+    return _run_cmd(cmd)
+
+
+def cmd_typecheck(extra_args: list[str]) -> int:
+    """Esegue il type checker mypy su services/."""
+    cmd = [sys.executable, "-m", "mypy", "services/"] + extra_args
+    return _run_cmd(cmd)
+
+
+def cmd_syntax(extra_args: list[str]) -> int:
+    """Verifica la sintassi Python compilando i moduli del progetto."""
+    cmd = [
+        sys.executable,
+        "-m",
+        "compileall",
+        "-q",
+        "bot.py",
+        "config.py",
+        "services",
+        "handlers",
+        "scripts",
+        "admin_pages",
+        "admin_ui.py",
+        "tools",
+    ] + extra_args
+    return _run_cmd(cmd)
+
+
+def cmd_dataset_check(extra_args: list[str]) -> int:
+    """Esegue il report e la verifica di integrita' del dataset calciatori."""
+    cmd = [sys.executable, "scripts/dataset_report.py", "--strict"] + extra_args
+    return _run_cmd(cmd)
+
+
+def cmd_check(extra_args: list[str]) -> int:
+    """Esegue l'intera suite di verifiche locali: sintassi, lint, mypy, dataset, test node e pytest."""
+    steps = [
+        ("Controllo ambiente", cmd_check_env, []),
+        ("Controllo sintassi (compileall)", cmd_syntax, []),
+        ("Lint (ruff)", cmd_lint, []),
+        ("Type check (mypy)", cmd_typecheck, []),
+        ("Integrita' dataset", cmd_dataset_check, []),
+        ("Test client (node)", cmd_test_node, []),
+        ("Unit test (pytest)", cmd_test, extra_args),
+    ]
+    for label, fn, args in steps:
+        print(f"\n=== [CHECK] {label} ===")
+        code = fn(args)
+        if code != 0:
+            print(f"\n[FAIL] Step '{label}' fallito con codice {code}. Interrompo.")
+            return code
+    print("\n[SUCCESS] Tutte le verifiche locali sono state superate con successo!")
+    return 0
+
+
+def cmd_api(extra_args: list[str]) -> int:
+    """Avvia il server FastAPI/bot in modalita' reload su localhost:8000."""
+    port = os.environ.get("PORT", "8000")
+    cmd = [sys.executable, "-m", "uvicorn", "bot:app", "--reload", "--port", port] + extra_args
+    return _run_cmd(cmd)
+
+
+def cmd_admin(extra_args: list[str]) -> int:
+    """Avvia la dashboard amministrativa Streamlit locale."""
+    cmd = [sys.executable, "-m", "streamlit", "run", "admin_ui.py"] + extra_args
+    return _run_cmd(cmd)
+
+
+def cmd_webapp(extra_args: list[str]) -> int:
+    """Avvia l'anteprima locale della Mini App su http://localhost:8888/app."""
+    cmd = [sys.executable, "scripts/preview_webapp.py"] + extra_args
+    return _run_cmd(cmd)
+
+
+def cmd_emulator(extra_args: list[str]) -> int:
+    """Avvia l'emulatore Google Cloud Firestore sulla porta standard 8571."""
+    host_port = os.environ.get("FIRESTORE_EMULATOR_HOST", "127.0.0.1:8571")
+    cmd = ["gcloud", "emulators", "firestore", "start", f"--host-port={host_port}"] + extra_args
+    return _run_cmd(cmd)
+
+
+# ---------------------------------------------------------------------------
+# Tabella comandi e CLI Dispatcher
+# ---------------------------------------------------------------------------
+
+COMMANDS: dict[str, tuple[Callable[[list[str]], int], str]] = {
+    "check-env": (cmd_check_env, "Verifica l'ambiente locale e configurazione (.env, dataset, python)"),
+    "test": (cmd_test, "Esegue i test unitari con pytest"),
+    "test-cov": (cmd_test_cov, "Esegue i test con report di copertura del codice"),
+    "test-node": (cmd_test_node, "Esegue i test client per la Mini App (richiede Node.js)"),
+    "lint": (cmd_lint, "Controlla il codice con ruff"),
+    "typecheck": (cmd_typecheck, "Verifica i tipi con mypy su services/"),
+    "syntax": (cmd_syntax, "Verifica la sintassi Python di tutti i moduli"),
+    "dataset-check": (cmd_dataset_check, "Controlla salute ed integrita' del dataset calciatori"),
+    "check": (cmd_check, "Esegue tutte le verifiche di qualita' (syntax, lint, mypy, dataset, test)"),
+    "api": (cmd_api, "Avvia il server API / bot con uvicorn (--reload)"),
+    "admin": (cmd_admin, "Avvia la dashboard admin con Streamlit (admin_ui.py)"),
+    "webapp": (cmd_webapp, "Avvia l'anteprima isolata della Mini App (preview_webapp.py)"),
+    "emulator": (cmd_emulator, "Avvia l'emulatore locale Firestore con gcloud"),
+}
+
+
+def print_help() -> None:
+    print("\n============================================================")
+    print(" Guess the Player - Comandi di sviluppo locale")
+    print("============================================================\n")
+    print("Uso: python -m tools.dev <comando> [argomenti...]\n")
+    print("Comandi disponibili:")
+    max_len = max(len(name) for name in COMMANDS)
+    for name, (_, desc) in COMMANDS.items():
+        print(f"  {name.ljust(max_len + 2)} : {desc}")
+    print("\nEsempi:")
+    print("  python -m tools.dev check-env")
+    print("  python -m tools.dev test")
+    print("  python -m tools.dev check")
+    print("  python -m tools.dev admin")
+    print("  python -m tools.dev webapp\n")
+
+
+def main(argv: Optional[list[str]] = None) -> int:
+    args = list(sys.argv[1:] if argv is None else argv)
+    if not args or args[0] in ("-h", "--help", "help"):
+        print_help()
+        return 0
+
+    cmd_name = args[0].lower()
+    extra_args = args[1:]
+
+    # Supporto per alias comuni
+    aliases = {
+        "check_env": "check-env",
+        "env": "check-env",
+        "tests": "test",
+        "coverage": "test-cov",
+        "type-check": "typecheck",
+        "check-dataset": "dataset-check",
+        "check_dataset": "dataset-check",
+        "check-all": "check",
+        "all": "check",
+        "dev-api": "api",
+        "dev-admin": "admin",
+        "dev-webapp": "webapp",
+        "dev-emulator": "emulator",
+    }
+    target_cmd = aliases.get(cmd_name, cmd_name)
+
+    if target_cmd not in COMMANDS:
+        print(f"Errore: comando sconosciuto '{cmd_name}'.")
+        print(f"Comandi validi: {', '.join(sorted(COMMANDS.keys()))}")
+        print("Usa 'python -m tools.dev --help' per l'elenco completo.")
+        return 1
+
+    fn, _ = COMMANDS[target_cmd]
+    return fn(extra_args)
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/tools/dev.py
+++ b/tools/dev.py
@@ -112,8 +112,14 @@ def cmd_dataset_check(extra_args: list[str]) -> int:
     return _run_cmd(cmd)
 
 
+def cmd_check_api(extra_args: list[str]) -> int:
+    """Verifica i requisiti per l'avvio del server FastAPI bot.py con tools.check_environment --mode api."""
+    cmd = [sys.executable, "-m", "tools.check_environment", "--mode", "api"] + extra_args
+    return _run_cmd(cmd)
+
+
 def cmd_check(extra_args: list[str]) -> int:
-    """Esegue l'intera suite di verifiche locali: sintassi, lint, mypy, dataset, test node e pytest."""
+    """Esegue la suite standard di validazione locale: sintassi, lint, mypy, dataset, test node e pytest."""
     steps = [
         ("Controllo ambiente", cmd_check_env, []),
         ("Controllo sintassi (compileall)", cmd_syntax, []),
@@ -129,12 +135,64 @@ def cmd_check(extra_args: list[str]) -> int:
         if code != 0:
             print(f"\n[FAIL] Step '{label}' fallito con codice {code}. Interrompo.")
             return code
-    print("\n[SUCCESS] Tutte le verifiche locali sono state superate con successo!")
+    print("\n[SUCCESS] Tutte le verifiche locali standard sono state superate con successo!")
     return 0
 
 
 def cmd_api(extra_args: list[str]) -> int:
-    """Avvia il server FastAPI/bot in modalita' reload su localhost:8000."""
+    """Avvia il server FastAPI/bot in modalita' reload su localhost:8000.
+
+    bot.py esegue il lifespan FastAPI completo e richiede configurate le variabili:
+    WEBHOOK_SECRET, TASK_SECRET, TASKS_QUEUE, BROADCAST_QUEUE e PUBLIC_BASE_URL (HTTPS).
+    Se mancano, fornisce un avviso chiaro ed azionabile prima di lanciare uvicorn.
+    """
+    import re
+    # Carica il file .env se non gia' presente in os.environ
+    env_file = ROOT_DIR / ".env"
+    if env_file.exists():
+        try:
+            from dotenv import load_dotenv
+            load_dotenv(env_file)
+        except Exception:
+            pass
+
+    webhook_secret = os.environ.get("WEBHOOK_SECRET", "").strip()
+    task_secret = os.environ.get("TASK_SECRET", "").strip()
+    tasks_queue = os.environ.get("TASKS_QUEUE", "").strip()
+    broadcast_queue = os.environ.get("BROADCAST_QUEUE", "").strip()
+    public_base_url = (os.environ.get("PUBLIC_BASE_URL") or "").strip().rstrip("/")
+
+    secret_pattern = r"^[A-Za-z0-9_-]{32,256}$"
+    missing = []
+
+    if not re.fullmatch(secret_pattern, webhook_secret):
+        missing.append("WEBHOOK_SECRET (richiesto da bot.py lifespan: 32-256 caratteri URL-safe)")
+    if not re.fullmatch(secret_pattern, task_secret):
+        missing.append("TASK_SECRET (richiesto da task_queue: 32-256 caratteri URL-safe)")
+    if not tasks_queue:
+        missing.append("TASKS_QUEUE (richiesto da task_queue.validate_configuration())")
+    if not broadcast_queue:
+        missing.append("BROADCAST_QUEUE (richiesto da task_queue.validate_configuration())")
+    if not public_base_url.startswith("https://"):
+        missing.append("PUBLIC_BASE_URL (richiesto con schema https:// da task_queue.validate_configuration())")
+
+    if missing:
+        print("\n============================================================")
+        print(" [ERRORE AVVIO API] Requisiti del runtime bot.py non soddisfatti")
+        print("============================================================\n")
+        print("Il server FastAPI 'bot.py' esegue controlli rigorosi al lifespan di avvio.")
+        print("I seguenti requisiti non sono soddisfatti nell'ambiente corrente:\n")
+        for item in missing:
+            print(f"  * {item}")
+        print("\nAzioni consigliate:")
+        print("  1. Per diagnosticare l'ambiente del server:")
+        print("     python -m tools.check_environment --mode api")
+        print("  2. Per configurare valori di test conformi nel .env consulta:")
+        print("     docs/local-development.md (Sezione 5.4)")
+        print("  3. Se desideri unicamente testare la Mini App senza il server bot.py:")
+        print("     make webapp   (oppure: python -m tools.dev webapp)\n")
+        return 1
+
     port = os.environ.get("PORT", "8000")
     cmd = [sys.executable, "-m", "uvicorn", "bot:app", "--reload", "--port", port] + extra_args
     return _run_cmd(cmd)
@@ -164,7 +222,8 @@ def cmd_emulator(extra_args: list[str]) -> int:
 # ---------------------------------------------------------------------------
 
 COMMANDS: dict[str, tuple[Callable[[list[str]], int], str]] = {
-    "check-env": (cmd_check_env, "Verifica l'ambiente locale e configurazione (.env, dataset, python)"),
+    "check-env": (cmd_check_env, "Verifica l'ambiente locale (modalita' dev: isolato per test/webapp/emulator)"),
+    "check-api": (cmd_check_api, "Verifica i requisiti per l'avvio del server FastAPI bot.py (lifespan e code)"),
     "test": (cmd_test, "Esegue i test unitari con pytest"),
     "test-cov": (cmd_test_cov, "Esegue i test con report di copertura del codice"),
     "test-node": (cmd_test_node, "Esegue i test client per la Mini App (richiede Node.js)"),
@@ -172,7 +231,7 @@ COMMANDS: dict[str, tuple[Callable[[list[str]], int], str]] = {
     "typecheck": (cmd_typecheck, "Verifica i tipi con mypy su services/"),
     "syntax": (cmd_syntax, "Verifica la sintassi Python di tutti i moduli"),
     "dataset-check": (cmd_dataset_check, "Controlla salute ed integrita' del dataset calciatori"),
-    "check": (cmd_check, "Esegue tutte le verifiche di qualita' (syntax, lint, mypy, dataset, test)"),
+    "check": (cmd_check, "Suite standard di validazione locale (ambiente, syntax, lint, mypy, dataset, test)"),
     "api": (cmd_api, "Avvia il server API / bot con uvicorn (--reload)"),
     "admin": (cmd_admin, "Avvia la dashboard admin con Streamlit (admin_ui.py)"),
     "webapp": (cmd_webapp, "Avvia l'anteprima isolata della Mini App (preview_webapp.py)"),
@@ -191,6 +250,7 @@ def print_help() -> None:
         print(f"  {name.ljust(max_len + 2)} : {desc}")
     print("\nEsempi:")
     print("  python -m tools.dev check-env")
+    print("  python -m tools.dev check-api")
     print("  python -m tools.dev test")
     print("  python -m tools.dev check")
     print("  python -m tools.dev admin")
@@ -210,6 +270,9 @@ def main(argv: Optional[list[str]] = None) -> int:
     aliases = {
         "check_env": "check-env",
         "env": "check-env",
+        "check_api": "check-api",
+        "api-check": "check-api",
+        "api_check": "check-api",
         "tests": "test",
         "coverage": "test-cov",
         "type-check": "typecheck",


### PR DESCRIPTION
## Summary
Closes #24

Questo PR introduce una suite integrata di comandi locali multipiattaforma e un validatore preventivo di configurazione/ambiente (`python -m tools.check_environment`) per rendere lo sviluppo locale riproducibile, autosufficiente e rapido nel diagnosticare configurazioni errate o mancanti.

Include inoltre la documentazione architetturale e operativa completa in `docs/local-development.md` e il collegamento rapido nel `README.md`.

## Developer workflow
Sono forniti tre punti di ingresso perfettamente equivalenti:
- `python -m tools.dev <command>` (indipendente dal sistema operativo, funziona ovunque)
- `make <command>` (per Linux, macOS, WSL e pipeline CI)
- `.\dev.ps1 <command>` (wrapper nativo PowerShell per Windows senza dipendenza da Make)

Comandi supportati:
- `check-env`: esegue la diagnostica dell'ambiente per lo sviluppo locale isolato (`tools.check_environment --mode dev`)
- `check-api`: verifica i requisiti specifici necessari per avviare il server FastAPI `bot.py` (`tools.check_environment --mode api`)
- `test`: esegue la suite di test unitari veloci (`pytest -q`)
- `test-cov`: esegue i test con report di copertura nel terminale
- `test-node`: esegue i test del client Mini App (`node --test tests/client.test.cjs`)
- `lint`: linter del codice Python (`ruff check .`)
- `typecheck`: verifica statica dei tipi (`mypy services/`)
- `syntax`: verifica sintassi Python sull'intero albero (`python -m compileall -q .`)
- `dataset-check`: validazione integrità e salute del dataset calciatori (`python scripts/dataset_report.py --strict`)
- `check`: esegue la **suite standard di validazione locale** (check-env, syntax, lint, typecheck, dataset-check, test-node, test)
- `emulator`: avvia l'emulatore Firebase Firestore locale su porta 8571
- `api`: avvia il backend FastAPI / webhook bot con uvicorn in reload mode su porta 8000 (con pre-check preventivo dei requisiti di lifespan)
- `admin`: avvia l'interfaccia di amministrazione Streamlit (`admin_ui.py`)
- `webapp`: avvia l'anteprima statica della Mini App con livereload su porta 8888 (`scripts/preview_webapp.py`)

## Environment validator
Il modulo `python -m tools.check_environment` analizza i requisiti necessari all'esecuzione e fornisce istruzioni di rimedio azionabili con codice di uscita standardizzato (0 = ok, 1 = failure o warning con `--strict`):
- **Versioni runtime**: verifica Python >= 3.11.
- **Dataset e statici**: verifica `data/players.json` (struttura dict con chiave `players`, id, full_name, career non vuote), `webapp/index.html`, `webapp/style.css`, `webapp/app.js`.
- **Configurazione e chiavi**:
  - `TELEGRAM_BOT_TOKEN`: formato id:hash e verifica che non sia il placeholder di default.
  - Modalità Firebase: in `dev`/`api`, con `FIRESTORE_EMULATOR_HOST` configurato, l'assenza di `firebase-key.json` è gestita come informativa; in `prod`, supporta sia la chiave di servizio JSON che le Application Default Credentials (ADC) del runtime cloud (es. Cloud Run Service Account o Workload Identity).
  - Presenza `.env`: in `prod` la presenza di un file `.env` locale non è richiesta (le variabili vengono lette direttamente dall'ambiente di sistema).
  - Distinzione tra sviluppo isolato e runtime `bot.py`:
    - `--mode dev`: per sviluppo isolato (test, emulatore, preview webapp); le code Cloud Tasks e i segreti di webhook sono opzionali (`[INFO]`).
    - `--mode api`: valida specificamente i requisiti del lifespan di `bot.py` (`WEBHOOK_SECRET`, `TASK_SECRET`, `TASKS_QUEUE`, `BROADCAST_QUEUE`, `PUBLIC_BASE_URL` con `https://`).
    - `--mode prod`: verifica rigorosa dei formati GCP e dei segreti di produzione su Cloud Run.
- **Tooling di sviluppo**: verifica disponibilità di `ruff`, `mypy`, `pytest`, `node`, `gcloud`, `java`.
- **Flag CLI**: supporta `--mode dev|api|prod|all`, `--strict`, `--json`, `--quiet`.

## Validation performed
- **Suite completa tramite runner**:
  - `python -m tools.dev check`: TUTTI i passaggi superati (15 OK, 1 WARN, 0 FAIL, 5 INFO su check-env; sintassi OK; ruff 0 errori; mypy 0 errori su 51 file; dataset_report OK; node test 23/23 OK; pytest 943 passati, 27 skippati).
- **Test con soglia coverage CI**:
  - `pytest -q --cov=services --cov=handlers --cov-report=term-missing --cov-fail-under=70` -> Copertura raggiunta: 75.34% (soglia minima 70% ampiamente superata).
- **Test dedicati per il PR**:
  - `tests/test_check_environment.py` (20 test unitari che coprono tutte le regole, `--mode dev`, `--mode api`, `--mode prod`, ADC, assenza `.env`, gestione errori, output JSON, e isolamento ambientale).
  - `tests/test_dev_commands.py` (7 test unitari per la risoluzione dei comandi, alias `check-api`, messaggi di help, e pre-check preventivo di `cmd_api`).
  - Esecuzione: `pytest -v tests/test_check_environment.py tests/test_dev_commands.py` -> 27 passed in 4.95s.
- **Verifica comandi wrapper**:
  - `python -m tools.dev --help`
  - `python -m tools.dev check-api`
  - `python -m tools.dev api` (blocco preventivo azionabile in assenza di segreti di lifespan)

## Limitations
- Il comando `emulator` richiede che Google Cloud SDK (`cloud-firestore-emulator`) e Java Runtime Environment (JRE) siano installati sulla macchina host. In loro assenza, il validatore e il runner segnalano un messaggio chiaro con i passi necessari.
- I comandi server di lunga durata (`api`, `admin`, `webapp`, `emulator`) sono pensati per essere lanciati in terminali separati o in background per consentire lo sviluppo concorrente.

## Risk
- **Basso**: non altera la logica di gioco, le regole di scoring, gli endpoint API né i controlli di sicurezza di `bot.py` o `services.task_queue`. I nuovi file sono confinati in `tools/`, script di supporto, test e documentazione.

## Roadmap
- Integrazione opzionale del controllo `python -m tools.check_environment --mode dev` come pre-commit hook facoltativo per gli sviluppatori.
- Script per il seed automatico di dati fittizi all'interno dell'emulatore Firestore locale per scenari di test end-to-end avanzati.
