### PR TITLE
feat(players): implement candidate player core model, states and isolated persistence (#54)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,6 +9,12 @@ __pycache__/
 # locali per costruzione, non fanno parte del dataset ufficiale finche' non sono importati.
 data/incoming/
 
+# Staging e storage isolato per il ciclo di vita dei Candidate Players (#54):
+data/candidates/
+
+# Worktree locali di sviluppo:
+.worktrees/
+
 # Export JSON di scripts/migrate_firestore.py: dati utente reali, non va committato.
 backup/
 # Report di coverage locale (in CI si rigenera ad ogni run).

--- a/services/candidate_player.py
+++ b/services/candidate_player.py
@@ -3,7 +3,7 @@
 Fornisce il modello e le regole fondamentali per la pipeline di ingestione dei calciatori:
 - Lifecycle states finiti ed espliciti (DISCOVERED -> ... -> APPROVED / REJECTED);
 - Macchina a stati rigida con eccezione dedicata per transizioni non consentite;
-- Generazione deterministica dell'identificativo del candidato;
+- Generazione deterministica dell'identificativo del candidato, immune a collisioni;
 - Tracciamento della cronologia delle transizioni (audit trail);
 - Tracciamento strutturato degli errori e dei tentativi di retry;
 - Separazione totale e rigorosa dal dataset di produzione data/players.json.
@@ -11,6 +11,7 @@ Fornisce il modello e le regole fondamentali per la pipeline di ingestione dei c
 from __future__ import annotations
 
 import copy
+import hashlib
 import re
 import unicodedata
 from dataclasses import dataclass, field
@@ -35,32 +36,46 @@ def _clean_slug(text: str) -> str:
 
 
 def make_candidate_id(source: str, source_id: str) -> str:
-    """Genera un identificatore deterministico e URL-safe per un candidato da fonte esterna.
+    """Genera un identificatore deterministico, collision-safe e URL/filesystem-safe per un candidato.
+
+    Combina uno slug leggibile con un hash crittografico stabile (SHA-256 a 8 caratteri esadecimali)
+    calcolato sui dati grezzi di source e source_id. Questo previene collisioni silenziose tra
+    identificatori esterni distinti che collasserebbero allo stesso slug (es. 'A-B', 'A/B', 'A_B').
 
     Esempio:
-        make_candidate_id("wikipedia", "Francesco Totti") -> "cand_wikipedia_francesco_totti"
-        make_candidate_id("wikidata", "Q1853") -> "cand_wikidata_q1853"
+        make_candidate_id("wikipedia", "Francesco Totti") -> "cand_wikipedia_francesco_totti_..."
+        make_candidate_id("wikidata", "Q1853") -> "cand_wikidata_q1853_..."
     """
     clean_src = _clean_slug(source)
     clean_id = _clean_slug(source_id)
-    if not clean_src or not clean_id:
+    if not clean_src or not str(source_id).strip():
         raise ValueError("source e source_id devono essere stringhe valide e non vuote")
-    return f"cand_{clean_src}_{clean_id}"
+
+    raw_token = f"{source.strip()}:{source_id.strip()}".encode("utf-8")
+    hash_suffix = hashlib.sha256(raw_token).hexdigest()[:8]
+
+    slug_part = clean_id[:40].rstrip("_") if clean_id else "item"
+    return f"cand_{clean_src}_{slug_part}_{hash_suffix}"
 
 
 def make_candidate_id_from_name(full_name: str, birth_year: Optional[int] = None) -> str:
-    """Genera un identificatore deterministico basato su nome e anno di nascita opzionale.
+    """Genera un identificatore deterministico e collision-safe basato su nome e anno di nascita.
 
     Esempio:
-        make_candidate_id_from_name("Lionel Messi", 1987) -> "cand_lionel_messi_1987"
-        make_candidate_id_from_name("Pelé") -> "cand_pele"
+        make_candidate_id_from_name("Lionel Messi", 1987) -> "cand_lionel_messi_1987_..."
+        make_candidate_id_from_name("Pelé") -> "cand_pele_..."
     """
     clean_name = _clean_slug(full_name)
     if not clean_name:
         raise ValueError("full_name deve essere una stringa valida e non vuota")
+
+    raw_token = f"{full_name.strip()}:{birth_year if birth_year is not None else ''}".encode("utf-8")
+    hash_suffix = hashlib.sha256(raw_token).hexdigest()[:8]
+
+    slug_part = clean_name[:40].rstrip("_")
     if birth_year is not None:
-        return f"cand_{clean_name}_{birth_year}"
-    return f"cand_{clean_name}"
+        return f"cand_{slug_part}_{birth_year}_{hash_suffix}"
+    return f"cand_{slug_part}_{hash_suffix}"
 
 
 class CandidateState(str, Enum):
@@ -214,67 +229,139 @@ class CandidateError:
         )
 
 
-@dataclass
+@dataclass(init=False, repr=True)
 class CandidatePlayer:
     """Modello di dominio per un calciatore candidato nella pipeline di ingestione.
 
     Isolato dal dataset di produzione, mantiene la storia delle transizioni, lo stato di
     avanzamento, i metadati di qualità/provenienza e i dettagli sugli errori/retry.
+
+    Lo stato del ciclo di vita (`status`) è protetto da modifiche dirette arbitrarie:
+    solo l'API di transizione `transition_to()` o il meccanismo di deserializzazione
+    possono impostare o far avanzare lo stato.
     """
 
     candidate_id: str
     source: str
     source_id: str
-    status: CandidateState = CandidateState.DISCOVERED
-    created_at: str = field(default_factory=_now_utc_iso)
-    updated_at: str = field(default_factory=_now_utc_iso)
-    last_transition_at: Optional[str] = None
+    _status: CandidateState
+    created_at: str
+    updated_at: str
+    last_transition_at: Optional[str]
 
     # Dati anagrafici e carriera (popolati progressivamente tra FETCHED e NORMALIZED)
-    full_name: Optional[str] = None
-    aliases: list[str] = field(default_factory=list)
-    nationality: Optional[str] = None
-    position: Optional[str] = None
-    birth_year: Optional[int] = None
-    popularity: Optional[int] = None
-    career: list[dict[str, Any]] = field(default_factory=list)
-    raw_data: dict[str, Any] = field(default_factory=dict)
+    full_name: Optional[str]
+    aliases: list[str]
+    nationality: Optional[str]
+    position: Optional[str]
+    birth_year: Optional[int]
+    popularity: Optional[int]
+    career: list[dict[str, Any]]
+    raw_data: dict[str, Any]
 
     # Indicatori di qualità e validazione (agganci per #26 e #27)
-    validation_warnings: list[str] = field(default_factory=list)
-    validation_errors: list[str] = field(default_factory=list)
-    confidence_score: Optional[float] = None
+    validation_warnings: list[str]
+    validation_errors: list[str]
+    confidence_score: Optional[float]
 
     # Gestione retry ed errori
-    retry_count: int = 0
-    max_retries: int = 3
-    errors: list[CandidateError] = field(default_factory=list)
-    last_error: Optional[CandidateError] = None
+    retry_count: int
+    max_retries: int
+    errors: list[CandidateError]
+    last_error: Optional[CandidateError]
 
     # Tracciamento e audit trail
-    state_history: list[StateTransitionRecord] = field(default_factory=list)
-    metadata: dict[str, Any] = field(default_factory=dict)
+    state_history: list[StateTransitionRecord]
+    metadata: dict[str, Any]
 
-    def __post_init__(self) -> None:
-        if isinstance(self.status, str):
-            self.status = CandidateState(self.status)
-        if not self.candidate_id:
+    def __init__(
+        self,
+        candidate_id: str,
+        source: str,
+        source_id: str,
+        *,
+        _status: CandidateState = CandidateState.DISCOVERED,
+        created_at: Optional[str] = None,
+        updated_at: Optional[str] = None,
+        last_transition_at: Optional[str] = None,
+        full_name: Optional[str] = None,
+        aliases: Optional[list[str]] = None,
+        nationality: Optional[str] = None,
+        position: Optional[str] = None,
+        birth_year: Optional[int] = None,
+        popularity: Optional[int] = None,
+        career: Optional[list[dict[str, Any]]] = None,
+        raw_data: Optional[dict[str, Any]] = None,
+        validation_warnings: Optional[list[str]] = None,
+        validation_errors: Optional[list[str]] = None,
+        confidence_score: Optional[float] = None,
+        retry_count: int = 0,
+        max_retries: int = 3,
+        errors: Optional[list[CandidateError]] = None,
+        last_error: Optional[CandidateError] = None,
+        state_history: Optional[list[StateTransitionRecord]] = None,
+        metadata: Optional[dict[str, Any]] = None,
+    ) -> None:
+        if not candidate_id:
             raise ValueError("candidate_id non puo' essere vuoto")
-        if not self.source or not self.source_id:
+        if not source or not source_id:
             raise ValueError("source e source_id devono essere valorizzati")
-        if not self.created_at:
-            self.created_at = _now_utc_iso()
-        if not self.updated_at:
-            self.updated_at = self.created_at
+
+        self.candidate_id = candidate_id
+        self.source = source
+        self.source_id = source_id
+
+        if isinstance(_status, str):
+            _status = CandidateState(_status)
+        self._status = _status
+
+        now = _now_utc_iso()
+        self.created_at = created_at or now
+        self.updated_at = updated_at or self.created_at
+        self.last_transition_at = last_transition_at
+
+        self.full_name = full_name
+        self.aliases = list(aliases) if aliases is not None else []
+        self.nationality = nationality
+        self.position = position
+        self.birth_year = birth_year
+        self.popularity = popularity
+        self.career = list(career) if career is not None else []
+        self.raw_data = dict(raw_data) if raw_data is not None else {}
+
+        self.validation_warnings = list(validation_warnings) if validation_warnings is not None else []
+        self.validation_errors = list(validation_errors) if validation_errors is not None else []
+        self.confidence_score = confidence_score
+
+        self.retry_count = int(retry_count)
+        self.max_retries = int(max_retries)
+        self.errors = list(errors) if errors is not None else []
+        self.last_error = last_error
+
+        self.state_history = list(state_history) if state_history is not None else []
+        self.metadata = dict(metadata) if metadata is not None else {}
+
+    @property
+    def status(self) -> CandidateState:
+        """Stato corrente del candidato nel ciclo di vita (in sola lettura)."""
+        return self._status
+
+    def __setattr__(self, name: str, value: Any) -> None:
+        if name == "status":
+            raise AttributeError(
+                "Lo stato del candidato non puo' essere modificato direttamente: "
+                "utilizzare candidate.transition_to() per eseguire una transizione validata."
+            )
+        super().__setattr__(name, value)
 
     def is_terminal(self) -> bool:
         """Indica se lo stato corrente e' terminale (APPROVED o REJECTED)."""
-        return self.status in (CandidateState.APPROVED, CandidateState.REJECTED)
+        return self._status in (CandidateState.APPROVED, CandidateState.REJECTED)
 
     def can_transition_to(self, target: CandidateState | str) -> bool:
         """Verifica se la transizione verso target e' lecita senza eseguirla."""
         target_state = target if isinstance(target, CandidateState) else CandidateState(target)
-        allowed = ALLOWED_TRANSITIONS.get(self.status, set())
+        allowed = ALLOWED_TRANSITIONS.get(self._status, set())
         return target_state in allowed
 
     def transition_to(
@@ -289,19 +376,19 @@ class CandidatePlayer:
         Solleva InvalidStateTransitionError se la transizione non e' consentita dal grafo.
         """
         target_state = target if isinstance(target, CandidateState) else CandidateState(target)
-        allowed = ALLOWED_TRANSITIONS.get(self.status, set())
+        allowed = ALLOWED_TRANSITIONS.get(self._status, set())
 
         if target_state not in allowed:
             raise InvalidStateTransitionError(
                 candidate_id=self.candidate_id,
-                current_state=self.status,
+                current_state=self._status,
                 target_state=target_state,
                 allowed_states=allowed,
             )
 
         now = _now_utc_iso()
         record = StateTransitionRecord(
-            from_state=self.status,
+            from_state=self._status,
             to_state=target_state,
             timestamp=now,
             reason=reason,
@@ -310,7 +397,7 @@ class CandidatePlayer:
         )
 
         self.state_history.append(record)
-        self.status = target_state
+        self._status = target_state
         self.last_transition_at = now
         self.updated_at = now
         return record
@@ -329,7 +416,7 @@ class CandidatePlayer:
             error_type=error_type,
             message=message,
             timestamp=now,
-            state=self.status,
+            state=self._status,
             details=dict(details or {}),
             retryable=retryable,
         )
@@ -361,7 +448,7 @@ class CandidatePlayer:
             "candidate_id": self.candidate_id,
             "source": self.source,
             "source_id": self.source_id,
-            "status": self.status.value,
+            "status": self._status.value,
             "created_at": self.created_at,
             "updated_at": self.updated_at,
             "last_transition_at": self.last_transition_at,
@@ -391,7 +478,7 @@ class CandidatePlayer:
             candidate_id=str(data["candidate_id"]),
             source=str(data["source"]),
             source_id=str(data["source_id"]),
-            status=CandidateState(data.get("status", CandidateState.DISCOVERED.value)),
+            _status=CandidateState(data.get("status", CandidateState.DISCOVERED.value)),
             created_at=str(data.get("created_at") or _now_utc_iso()),
             updated_at=str(data.get("updated_at") or _now_utc_iso()),
             last_transition_at=data.get("last_transition_at"),

--- a/services/candidate_player.py
+++ b/services/candidate_player.py
@@ -1,0 +1,416 @@
+"""Candidate Player Core — modello di dominio, stati del ciclo di vita e transizioni.
+
+Fornisce il modello e le regole fondamentali per la pipeline di ingestione dei calciatori:
+- Lifecycle states finiti ed espliciti (DISCOVERED -> ... -> APPROVED / REJECTED);
+- Macchina a stati rigida con eccezione dedicata per transizioni non consentite;
+- Generazione deterministica dell'identificativo del candidato;
+- Tracciamento della cronologia delle transizioni (audit trail);
+- Tracciamento strutturato degli errori e dei tentativi di retry;
+- Separazione totale e rigorosa dal dataset di produzione data/players.json.
+"""
+from __future__ import annotations
+
+import copy
+import re
+import unicodedata
+from dataclasses import dataclass, field
+from datetime import datetime, timezone
+from enum import Enum
+from typing import Any, Optional
+
+
+def _now_utc_iso() -> str:
+    """Restituisce il timestamp UTC corrente in formato ISO-8601 YYYY-MM-DDTHH:MM:SSZ."""
+    return datetime.now(timezone.utc).strftime("%Y-%m-%dT%H:%M:%SZ")
+
+
+def _clean_slug(text: str) -> str:
+    """Normalizza una stringa in uno slug minuscolo, senza accenti e con underscore."""
+    if not text:
+        return ""
+    decomposed = unicodedata.normalize("NFKD", str(text).strip().lower())
+    without_accents = "".join(char for char in decomposed if not unicodedata.combining(char))
+    cleaned = re.sub(r"[^a-z0-9]+", "_", without_accents)
+    return cleaned.strip("_")
+
+
+def make_candidate_id(source: str, source_id: str) -> str:
+    """Genera un identificatore deterministico e URL-safe per un candidato da fonte esterna.
+
+    Esempio:
+        make_candidate_id("wikipedia", "Francesco Totti") -> "cand_wikipedia_francesco_totti"
+        make_candidate_id("wikidata", "Q1853") -> "cand_wikidata_q1853"
+    """
+    clean_src = _clean_slug(source)
+    clean_id = _clean_slug(source_id)
+    if not clean_src or not clean_id:
+        raise ValueError("source e source_id devono essere stringhe valide e non vuote")
+    return f"cand_{clean_src}_{clean_id}"
+
+
+def make_candidate_id_from_name(full_name: str, birth_year: Optional[int] = None) -> str:
+    """Genera un identificatore deterministico basato su nome e anno di nascita opzionale.
+
+    Esempio:
+        make_candidate_id_from_name("Lionel Messi", 1987) -> "cand_lionel_messi_1987"
+        make_candidate_id_from_name("Pelé") -> "cand_pele"
+    """
+    clean_name = _clean_slug(full_name)
+    if not clean_name:
+        raise ValueError("full_name deve essere una stringa valida e non vuota")
+    if birth_year is not None:
+        return f"cand_{clean_name}_{birth_year}"
+    return f"cand_{clean_name}"
+
+
+class CandidateState(str, Enum):
+    """Stati del ciclo di vita di un candidato calciatore nella pipeline."""
+
+    DISCOVERED = "DISCOVERED"
+    FETCHED = "FETCHED"
+    NORMALIZED = "NORMALIZED"
+    VALIDATED = "VALIDATED"
+    REVIEW_REQUIRED = "REVIEW_REQUIRED"
+    READY = "READY"
+    APPROVED = "APPROVED"
+    REJECTED = "REJECTED"
+
+
+# Grafo esplicito delle transizioni consentite tra gli stati.
+ALLOWED_TRANSITIONS: dict[CandidateState, set[CandidateState]] = {
+    CandidateState.DISCOVERED: {
+        CandidateState.FETCHED,
+        CandidateState.REJECTED,
+    },
+    CandidateState.FETCHED: {
+        CandidateState.NORMALIZED,
+        CandidateState.REVIEW_REQUIRED,
+        CandidateState.REJECTED,
+    },
+    CandidateState.NORMALIZED: {
+        CandidateState.VALIDATED,
+        CandidateState.REVIEW_REQUIRED,
+        CandidateState.REJECTED,
+    },
+    CandidateState.VALIDATED: {
+        CandidateState.READY,
+        CandidateState.REVIEW_REQUIRED,
+        CandidateState.APPROVED,
+        CandidateState.REJECTED,
+    },
+    CandidateState.REVIEW_REQUIRED: {
+        CandidateState.READY,
+        CandidateState.APPROVED,
+        CandidateState.REJECTED,
+        CandidateState.FETCHED,
+        CandidateState.NORMALIZED,
+    },
+    CandidateState.READY: {
+        CandidateState.APPROVED,
+        CandidateState.REJECTED,
+        CandidateState.REVIEW_REQUIRED,
+    },
+    # APPROVED e REJECTED sono deliberatamente considerati stati terminali:
+    # una volta che una decisione finale e' stata presa, il record e' archiviato
+    # e non puo' essere reimmesso in transizione attiva senza un nuovo ciclo di ingestion.
+    CandidateState.APPROVED: set(),
+    CandidateState.REJECTED: set(),
+}
+
+
+class CandidateCoreError(Exception):
+    """Eccezione base per errori del modulo Candidate Player Core."""
+
+
+class InvalidStateTransitionError(CandidateCoreError):
+    """Sollevata quando si tenta una transizione di stato non consentita."""
+
+    def __init__(
+        self,
+        candidate_id: str,
+        current_state: CandidateState,
+        target_state: CandidateState,
+        allowed_states: set[CandidateState],
+    ) -> None:
+        self.candidate_id = candidate_id
+        self.current_state = current_state
+        self.target_state = target_state
+        self.allowed_states = allowed_states
+        allowed_str = (
+            ", ".join(s.value for s in sorted(allowed_states, key=lambda s: s.value))
+            if allowed_states
+            else "nessuna (stato terminale)"
+        )
+        super().__init__(
+            f"Transizione non valida per il candidato '{candidate_id}': "
+            f"impossibile passare da '{current_state.value}' a '{target_state.value}'. "
+            f"Transizioni consentite: [{allowed_str}]."
+        )
+
+
+@dataclass
+class StateTransitionRecord:
+    """Registrazione immutabile di una transizione di stato per l'audit trail."""
+
+    from_state: CandidateState
+    to_state: CandidateState
+    timestamp: str
+    reason: Optional[str] = None
+    actor: Optional[str] = None
+    metadata: dict[str, Any] = field(default_factory=dict)
+
+    def to_dict(self) -> dict[str, Any]:
+        return {
+            "from_state": self.from_state.value,
+            "to_state": self.to_state.value,
+            "timestamp": self.timestamp,
+            "reason": self.reason,
+            "actor": self.actor,
+            "metadata": copy.deepcopy(self.metadata),
+        }
+
+    @classmethod
+    def from_dict(cls, data: dict[str, Any]) -> StateTransitionRecord:
+        return cls(
+            from_state=CandidateState(data["from_state"]),
+            to_state=CandidateState(data["to_state"]),
+            timestamp=str(data["timestamp"]),
+            reason=data.get("reason"),
+            actor=data.get("actor"),
+            metadata=dict(data.get("metadata", {})),
+        )
+
+
+@dataclass
+class CandidateError:
+    """Struttura per memorizzare informazioni dettagliate su fallimenti e warning."""
+
+    error_type: str
+    message: str
+    timestamp: str
+    state: CandidateState
+    details: dict[str, Any] = field(default_factory=dict)
+    retryable: bool = True
+
+    def to_dict(self) -> dict[str, Any]:
+        return {
+            "error_type": self.error_type,
+            "message": self.message,
+            "timestamp": self.timestamp,
+            "state": self.state.value,
+            "details": copy.deepcopy(self.details),
+            "retryable": self.retryable,
+        }
+
+    @classmethod
+    def from_dict(cls, data: dict[str, Any]) -> CandidateError:
+        return cls(
+            error_type=str(data["error_type"]),
+            message=str(data["message"]),
+            timestamp=str(data["timestamp"]),
+            state=CandidateState(data["state"]),
+            details=dict(data.get("details", {})),
+            retryable=bool(data.get("retryable", True)),
+        )
+
+
+@dataclass
+class CandidatePlayer:
+    """Modello di dominio per un calciatore candidato nella pipeline di ingestione.
+
+    Isolato dal dataset di produzione, mantiene la storia delle transizioni, lo stato di
+    avanzamento, i metadati di qualità/provenienza e i dettagli sugli errori/retry.
+    """
+
+    candidate_id: str
+    source: str
+    source_id: str
+    status: CandidateState = CandidateState.DISCOVERED
+    created_at: str = field(default_factory=_now_utc_iso)
+    updated_at: str = field(default_factory=_now_utc_iso)
+    last_transition_at: Optional[str] = None
+
+    # Dati anagrafici e carriera (popolati progressivamente tra FETCHED e NORMALIZED)
+    full_name: Optional[str] = None
+    aliases: list[str] = field(default_factory=list)
+    nationality: Optional[str] = None
+    position: Optional[str] = None
+    birth_year: Optional[int] = None
+    popularity: Optional[int] = None
+    career: list[dict[str, Any]] = field(default_factory=list)
+    raw_data: dict[str, Any] = field(default_factory=dict)
+
+    # Indicatori di qualità e validazione (agganci per #26 e #27)
+    validation_warnings: list[str] = field(default_factory=list)
+    validation_errors: list[str] = field(default_factory=list)
+    confidence_score: Optional[float] = None
+
+    # Gestione retry ed errori
+    retry_count: int = 0
+    max_retries: int = 3
+    errors: list[CandidateError] = field(default_factory=list)
+    last_error: Optional[CandidateError] = None
+
+    # Tracciamento e audit trail
+    state_history: list[StateTransitionRecord] = field(default_factory=list)
+    metadata: dict[str, Any] = field(default_factory=dict)
+
+    def __post_init__(self) -> None:
+        if isinstance(self.status, str):
+            self.status = CandidateState(self.status)
+        if not self.candidate_id:
+            raise ValueError("candidate_id non puo' essere vuoto")
+        if not self.source or not self.source_id:
+            raise ValueError("source e source_id devono essere valorizzati")
+        if not self.created_at:
+            self.created_at = _now_utc_iso()
+        if not self.updated_at:
+            self.updated_at = self.created_at
+
+    def is_terminal(self) -> bool:
+        """Indica se lo stato corrente e' terminale (APPROVED o REJECTED)."""
+        return self.status in (CandidateState.APPROVED, CandidateState.REJECTED)
+
+    def can_transition_to(self, target: CandidateState | str) -> bool:
+        """Verifica se la transizione verso target e' lecita senza eseguirla."""
+        target_state = target if isinstance(target, CandidateState) else CandidateState(target)
+        allowed = ALLOWED_TRANSITIONS.get(self.status, set())
+        return target_state in allowed
+
+    def transition_to(
+        self,
+        target: CandidateState | str,
+        reason: Optional[str] = None,
+        actor: Optional[str] = None,
+        metadata: Optional[dict[str, Any]] = None,
+    ) -> StateTransitionRecord:
+        """Esegue la transizione verso il nuovo stato, aggiornando timestamp e cronologia.
+
+        Solleva InvalidStateTransitionError se la transizione non e' consentita dal grafo.
+        """
+        target_state = target if isinstance(target, CandidateState) else CandidateState(target)
+        allowed = ALLOWED_TRANSITIONS.get(self.status, set())
+
+        if target_state not in allowed:
+            raise InvalidStateTransitionError(
+                candidate_id=self.candidate_id,
+                current_state=self.status,
+                target_state=target_state,
+                allowed_states=allowed,
+            )
+
+        now = _now_utc_iso()
+        record = StateTransitionRecord(
+            from_state=self.status,
+            to_state=target_state,
+            timestamp=now,
+            reason=reason,
+            actor=actor,
+            metadata=dict(metadata or {}),
+        )
+
+        self.state_history.append(record)
+        self.status = target_state
+        self.last_transition_at = now
+        self.updated_at = now
+        return record
+
+    def record_error(
+        self,
+        error_type: str,
+        message: str,
+        details: Optional[dict[str, Any]] = None,
+        retryable: bool = True,
+        increment_retry_count: bool = True,
+    ) -> CandidateError:
+        """Registra un errore strutturato e aggiorna lo stato dei tentativi."""
+        now = _now_utc_iso()
+        err = CandidateError(
+            error_type=error_type,
+            message=message,
+            timestamp=now,
+            state=self.status,
+            details=dict(details or {}),
+            retryable=retryable,
+        )
+        self.errors.append(err)
+        self.last_error = err
+        if retryable and increment_retry_count:
+            self.retry_count += 1
+        self.updated_at = now
+        return err
+
+    def increment_retry(self) -> int:
+        """Incrementa il conteggio dei tentativi e aggiorna updated_at."""
+        self.retry_count += 1
+        self.updated_at = _now_utc_iso()
+        return self.retry_count
+
+    def reset_retries(self) -> None:
+        """Azzera il contatore dei tentativi."""
+        self.retry_count = 0
+        self.updated_at = _now_utc_iso()
+
+    def can_retry(self) -> bool:
+        """Indica se e' possibile effettuare un ulteriore tentativo di retry."""
+        return self.retry_count < self.max_retries
+
+    def to_dict(self) -> dict[str, Any]:
+        """Serializza il candidato in un dizionario compatibile con JSON."""
+        return {
+            "candidate_id": self.candidate_id,
+            "source": self.source,
+            "source_id": self.source_id,
+            "status": self.status.value,
+            "created_at": self.created_at,
+            "updated_at": self.updated_at,
+            "last_transition_at": self.last_transition_at,
+            "full_name": self.full_name,
+            "aliases": list(self.aliases),
+            "nationality": self.nationality,
+            "position": self.position,
+            "birth_year": self.birth_year,
+            "popularity": self.popularity,
+            "career": copy.deepcopy(self.career),
+            "raw_data": copy.deepcopy(self.raw_data),
+            "validation_warnings": list(self.validation_warnings),
+            "validation_errors": list(self.validation_errors),
+            "confidence_score": self.confidence_score,
+            "retry_count": self.retry_count,
+            "max_retries": self.max_retries,
+            "errors": [e.to_dict() for e in self.errors],
+            "last_error": self.last_error.to_dict() if self.last_error else None,
+            "state_history": [r.to_dict() for r in self.state_history],
+            "metadata": copy.deepcopy(self.metadata),
+        }
+
+    @classmethod
+    def from_dict(cls, data: dict[str, Any]) -> CandidatePlayer:
+        """Ricostruisce un CandidatePlayer da una rappresentazione a dizionario."""
+        candidate = cls(
+            candidate_id=str(data["candidate_id"]),
+            source=str(data["source"]),
+            source_id=str(data["source_id"]),
+            status=CandidateState(data.get("status", CandidateState.DISCOVERED.value)),
+            created_at=str(data.get("created_at") or _now_utc_iso()),
+            updated_at=str(data.get("updated_at") or _now_utc_iso()),
+            last_transition_at=data.get("last_transition_at"),
+            full_name=data.get("full_name"),
+            aliases=list(data.get("aliases") or []),
+            nationality=data.get("nationality"),
+            position=data.get("position"),
+            birth_year=data.get("birth_year"),
+            popularity=data.get("popularity"),
+            career=list(data.get("career") or []),
+            raw_data=dict(data.get("raw_data") or {}),
+            validation_warnings=list(data.get("validation_warnings") or []),
+            validation_errors=list(data.get("validation_errors") or []),
+            confidence_score=data.get("confidence_score"),
+            retry_count=int(data.get("retry_count", 0)),
+            max_retries=int(data.get("max_retries", 3)),
+            errors=[CandidateError.from_dict(e) for e in (data.get("errors") or [])],
+            last_error=CandidateError.from_dict(data["last_error"]) if data.get("last_error") else None,
+            state_history=[StateTransitionRecord.from_dict(r) for r in (data.get("state_history") or [])],
+            metadata=dict(data.get("metadata") or {}),
+        )
+        return candidate

--- a/services/repos/candidates.py
+++ b/services/repos/candidates.py
@@ -1,0 +1,257 @@
+"""Repository abstraction and isolated persistence for Candidate Players.
+
+Garantisce:
+- Astrazione repository (CandidatePlayerRepository) per disaccoppiare la logica di dominio;
+- Implementazione in-memory (InMemoryCandidatePlayerRepository) veloce e deterministica per test;
+- Implementazione file-backed (FileCandidatePlayerRepository) su filesystem locale;
+- Totale e rigoroso isolamento da data/players.json (nessuna scrittura sul dataset di produzione);
+- Scritture atomiche su file per prevenire corruzioni di dati in caso di interruzione.
+"""
+from __future__ import annotations
+
+import abc
+import copy
+import json
+import os
+import tempfile
+from pathlib import Path
+from typing import Optional
+
+from services.candidate_player import CandidatePlayer, CandidateState
+
+
+class CandidateRepositoryError(Exception):
+    """Eccezione base per errori del repository dei candidati."""
+
+
+class CandidatePlayerRepository(abc.ABC):
+    """Interfaccia astratta del repository per il ciclo di vita dei candidati calciatori."""
+
+    @abc.abstractmethod
+    def save(self, candidate: CandidatePlayer) -> None:
+        """Salva o aggiorna un candidato."""
+        raise NotImplementedError
+
+    @abc.abstractmethod
+    def get_by_id(self, candidate_id: str) -> Optional[CandidatePlayer]:
+        """Recupera un candidato per ID univoco, o None se inesistente."""
+        raise NotImplementedError
+
+    @abc.abstractmethod
+    def exists(self, candidate_id: str) -> bool:
+        """Verifica l'esistenza di un candidato per ID."""
+        raise NotImplementedError
+
+    @abc.abstractmethod
+    def list_all(self, limit: Optional[int] = None, offset: int = 0) -> list[CandidatePlayer]:
+        """Restituisce tutti i candidati con ordinamento deterministico."""
+        raise NotImplementedError
+
+    @abc.abstractmethod
+    def find_by_state(
+        self,
+        state: CandidateState | str,
+        limit: Optional[int] = None,
+        offset: int = 0,
+    ) -> list[CandidatePlayer]:
+        """Filtra i candidati per stato del ciclo di vita."""
+        raise NotImplementedError
+
+    @abc.abstractmethod
+    def count(self, state: Optional[CandidateState | str] = None) -> int:
+        """Restituisce il numero totale di candidati, o di candidati in uno stato specifico."""
+        raise NotImplementedError
+
+    @abc.abstractmethod
+    def delete(self, candidate_id: str) -> bool:
+        """Elimina un candidato per ID. Ritorna True se rimosso, False se non trovato."""
+        raise NotImplementedError
+
+
+class InMemoryCandidatePlayerRepository(CandidatePlayerRepository):
+    """Implementazione in-memory thread-safe e isolata, ideale per test veloci."""
+
+    def __init__(self) -> None:
+        self._storage: dict[str, dict] = {}
+
+    def save(self, candidate: CandidatePlayer) -> None:
+        # Serializza a dizionario per garantire isolamento da modifiche per riferimento
+        self._storage[candidate.candidate_id] = candidate.to_dict()
+
+    def get_by_id(self, candidate_id: str) -> Optional[CandidatePlayer]:
+        data = self._storage.get(candidate_id)
+        if data is None:
+            return None
+        return CandidatePlayer.from_dict(copy.deepcopy(data))
+
+    def exists(self, candidate_id: str) -> bool:
+        return candidate_id in self._storage
+
+    def list_all(self, limit: Optional[int] = None, offset: int = 0) -> list[CandidatePlayer]:
+        # Ordinamento deterministico per candidate_id
+        sorted_keys = sorted(self._storage.keys())
+        sliced = sorted_keys[offset:]
+        if limit is not None:
+            sliced = sliced[:limit]
+        return [CandidatePlayer.from_dict(copy.deepcopy(self._storage[k])) for k in sliced]
+
+    def find_by_state(
+        self,
+        state: CandidateState | str,
+        limit: Optional[int] = None,
+        offset: int = 0,
+    ) -> list[CandidatePlayer]:
+        target_state = state if isinstance(state, CandidateState) else CandidateState(state)
+        matching = [
+            CandidatePlayer.from_dict(copy.deepcopy(data))
+            for k, data in sorted(self._storage.items())
+            if data.get("status") == target_state.value
+        ]
+        sliced = matching[offset:]
+        if limit is not None:
+            sliced = sliced[:limit]
+        return sliced
+
+    def count(self, state: Optional[CandidateState | str] = None) -> int:
+        if state is None:
+            return len(self._storage)
+        target_state = state if isinstance(state, CandidateState) else CandidateState(state)
+        return sum(1 for data in self._storage.values() if data.get("status") == target_state.value)
+
+    def delete(self, candidate_id: str) -> bool:
+        if candidate_id in self._storage:
+            del self._storage[candidate_id]
+            return True
+        return False
+
+    def clear(self) -> None:
+        """Svuota completamente il repository in memoria."""
+        self._storage.clear()
+
+
+class FileCandidatePlayerRepository(CandidatePlayerRepository):
+    """Implementazione su filesystem con un file JSON per candidato.
+
+    Garantisce:
+    - Scrittura atomica per prevenire file troncati;
+    - Isolamento rigoroso: rifiuta esplicitamente percorsi coincidenti con data/players.json;
+    - Formato JSON con indentazione a 2 spazi e senza escape ASCII;
+    - Determinismo e serializzazione/deserializzazione completa.
+    """
+
+    DEFAULT_DIR = Path("data") / "candidates"
+
+    def __init__(self, storage_dir: Optional[Path | str] = None) -> None:
+        raw_path = Path(storage_dir) if storage_dir is not None else self.DEFAULT_DIR
+        self._dir = raw_path.resolve()
+
+        # Guard di sicurezza fondamentale: impedisce categoricamente di puntare
+        # a data/players.json o di salvare candidati dentro il file di produzione.
+        self._assert_storage_isolated(self._dir)
+        self._dir.mkdir(parents=True, exist_ok=True)
+
+    @classmethod
+    def _assert_storage_isolated(cls, resolved_dir: Path) -> None:
+        """Verifica che la directory di storage non coincida né contenga il dataset di produzione."""
+        # Percorso canonico di data/players.json
+        base_repo = Path(__file__).resolve().parents[2]
+        prod_file = (base_repo / "data" / "players.json").resolve()
+
+        if resolved_dir == prod_file or resolved_dir.name.lower() == "players.json":
+            raise CandidateRepositoryError(
+                f"Violazione di sicurezza: il repository candidati non puo' puntare al file di produzione: {prod_file}"
+            )
+
+    def _file_path(self, candidate_id: str) -> Path:
+        # Sanificazione del candidate_id per prevenire path traversal
+        clean_id = Path(candidate_id).name
+        if clean_id != candidate_id or ".." in candidate_id or "/" in candidate_id or "\\" in candidate_id:
+            raise ValueError(f"candidate_id non valido per il filesystem: '{candidate_id}'")
+        return self._dir / f"{clean_id}.json"
+
+    def save(self, candidate: CandidatePlayer) -> None:
+        """Salva il candidato su file JSON in modo atomico."""
+        dest_path = self._file_path(candidate.candidate_id)
+
+        # Scrittura atomica: crea file temporaneo nella stessa cartella e poi esegue replace
+        tmp_fd, tmp_path_str = tempfile.mkstemp(
+            prefix=f".tmp_{candidate.candidate_id}_",
+            suffix=".json",
+            dir=str(self._dir),
+        )
+        try:
+            with open(tmp_fd, "w", encoding="utf-8") as f:
+                json.dump(candidate.to_dict(), f, indent=2, ensure_ascii=False)
+                f.flush()
+                os.fsync(f.fileno())
+            os.replace(tmp_path_str, str(dest_path))
+        except Exception:
+            if os.path.exists(tmp_path_str):
+                try:
+                    os.unlink(tmp_path_str)
+                except OSError:
+                    pass
+            raise
+
+    def get_by_id(self, candidate_id: str) -> Optional[CandidatePlayer]:
+        path = self._file_path(candidate_id)
+        if not path.is_file():
+            return None
+        with open(path, "r", encoding="utf-8") as f:
+            data = json.load(f)
+        return CandidatePlayer.from_dict(data)
+
+    def exists(self, candidate_id: str) -> bool:
+        try:
+            return self._file_path(candidate_id).is_file()
+        except ValueError:
+            return False
+
+    def list_all(self, limit: Optional[int] = None, offset: int = 0) -> list[CandidatePlayer]:
+        files = sorted(self._dir.glob("*.json"))
+        # Esclude file temporanei o nascosti
+        valid_files = [f for f in files if not f.name.startswith(".")]
+        sliced = valid_files[offset:]
+        if limit is not None:
+            sliced = sliced[:limit]
+
+        results = []
+        for path in sliced:
+            with open(path, "r", encoding="utf-8") as f:
+                data = json.load(f)
+            results.append(CandidatePlayer.from_dict(data))
+        return results
+
+    def find_by_state(
+        self,
+        state: CandidateState | str,
+        limit: Optional[int] = None,
+        offset: int = 0,
+    ) -> list[CandidatePlayer]:
+        target_state = state if isinstance(state, CandidateState) else CandidateState(state)
+        all_candidates = self.list_all()
+        matching = [c for c in all_candidates if c.status == target_state]
+        sliced = matching[offset:]
+        if limit is not None:
+            sliced = sliced[:limit]
+        return sliced
+
+    def count(self, state: Optional[CandidateState | str] = None) -> int:
+        if state is None:
+            files = [f for f in self._dir.glob("*.json") if not f.name.startswith(".")]
+            return len(files)
+        target_state = state if isinstance(state, CandidateState) else CandidateState(state)
+        return len(self.find_by_state(target_state))
+
+    def delete(self, candidate_id: str) -> bool:
+        try:
+            path = self._file_path(candidate_id)
+        except ValueError:
+            return False
+        if path.is_file():
+            try:
+                path.unlink()
+                return True
+            except FileNotFoundError:
+                return False
+        return False

--- a/services/repos/candidates.py
+++ b/services/repos/candidates.py
@@ -69,7 +69,7 @@ class CandidatePlayerRepository(abc.ABC):
 
 
 class InMemoryCandidatePlayerRepository(CandidatePlayerRepository):
-    """Implementazione in-memory thread-safe e isolata, ideale per test veloci."""
+    """Implementazione in-memory veloce e isolata, ideale per test unitari deterministici."""
 
     def __init__(self) -> None:
         self._storage: dict[str, dict] = {}

--- a/tests/test_candidate_player.py
+++ b/tests/test_candidate_player.py
@@ -1,0 +1,310 @@
+"""Unit tests for Candidate Player domain model, states, transitions, errors, and IDs."""
+import json
+
+import pytest
+
+from services.candidate_player import (
+    CandidateError,
+    CandidatePlayer,
+    CandidateState,
+    InvalidStateTransitionError,
+    make_candidate_id,
+    make_candidate_id_from_name,
+)
+
+
+def test_candidate_creation_defaults():
+    candidate = CandidatePlayer(
+        candidate_id="cand_wiki_francesco_totti",
+        source="wikipedia",
+        source_id="Francesco_Totti",
+    )
+
+    assert candidate.candidate_id == "cand_wiki_francesco_totti"
+    assert candidate.source == "wikipedia"
+    assert candidate.source_id == "Francesco_Totti"
+    assert candidate.status == CandidateState.DISCOVERED
+    assert candidate.created_at != ""
+    assert candidate.updated_at != ""
+    assert candidate.last_transition_at is None
+    assert candidate.state_history == []
+    assert candidate.errors == []
+    assert candidate.last_error is None
+    assert candidate.retry_count == 0
+    assert candidate.max_retries == 3
+    assert candidate.is_terminal() is False
+    assert candidate.can_retry() is True
+
+
+def test_candidate_creation_validation():
+    with pytest.raises(ValueError, match="candidate_id non puo' essere vuoto"):
+        CandidatePlayer(candidate_id="", source="wikipedia", source_id="123")
+
+    with pytest.raises(ValueError, match="source e source_id devono essere valorizzati"):
+        CandidatePlayer(candidate_id="cand_1", source="", source_id="123")
+
+    with pytest.raises(ValueError, match="source e source_id devono essere valorizzati"):
+        CandidatePlayer(candidate_id="cand_1", source="wiki", source_id="")
+
+
+def test_deterministic_id_generation():
+    id1 = make_candidate_id("wikipedia", "Francesco Totti")
+    id2 = make_candidate_id("WIKIPEDIA", "francesco totti")
+    id3 = make_candidate_id("  Wikipedia  ", "Francesco   Totti  ")
+
+    assert id1 == "cand_wikipedia_francesco_totti"
+    assert id1 == id2 == id3
+
+    # Accenti e caratteri speciali
+    id_accent = make_candidate_id("wikipedia", "Pelé")
+    assert id_accent == "cand_wikipedia_pele"
+
+    id_apostrophe = make_candidate_id("wiki", "N'Golo Kanté")
+    assert id_apostrophe == "cand_wiki_n_golo_kante"
+
+    # Wikidata Q-ID
+    id_wd = make_candidate_id("wikidata", "Q1853")
+    assert id_wd == "cand_wikidata_q1853"
+
+
+def test_deterministic_id_invalid_inputs():
+    with pytest.raises(ValueError, match="source e source_id devono essere stringhe valide"):
+        make_candidate_id("", "foo")
+    with pytest.raises(ValueError, match="source e source_id devono essere stringhe valide"):
+        make_candidate_id("wiki", "")
+
+
+def test_deterministic_id_from_name():
+    id1 = make_candidate_id_from_name("Lionel Messi", 1987)
+    id2 = make_candidate_id_from_name("lionel messi", 1987)
+    assert id1 == "cand_lionel_messi_1987"
+    assert id1 == id2
+
+    id_no_year = make_candidate_id_from_name("Zinedine Zidane")
+    assert id_no_year == "cand_zinedine_zidane"
+
+    with pytest.raises(ValueError, match="full_name deve essere una stringa valida"):
+        make_candidate_id_from_name("   ")
+
+
+def test_legal_transitions_lifecycle_happy_path():
+    cand = CandidatePlayer(
+        candidate_id="cand_test_player",
+        source="wiki",
+        source_id="Test_Player",
+    )
+    assert cand.status == CandidateState.DISCOVERED
+    assert cand.can_transition_to(CandidateState.FETCHED) is True
+    assert cand.can_transition_to(CandidateState.APPROVED) is False
+
+    # 1. DISCOVERED -> FETCHED
+    rec1 = cand.transition_to(CandidateState.FETCHED, reason="Fetched raw wiki page", actor="adapter_wiki")
+    assert cand.status == CandidateState.FETCHED
+    assert cand.last_transition_at is not None
+    assert len(cand.state_history) == 1
+    assert rec1.from_state == CandidateState.DISCOVERED
+    assert rec1.to_state == CandidateState.FETCHED
+    assert rec1.reason == "Fetched raw wiki page"
+    assert rec1.actor == "adapter_wiki"
+
+    # 2. FETCHED -> NORMALIZED
+    cand.transition_to(CandidateState.NORMALIZED, reason="Cleaned club names")
+    assert cand.status == CandidateState.NORMALIZED
+    assert len(cand.state_history) == 2
+
+    # 3. NORMALIZED -> VALIDATED
+    cand.transition_to(CandidateState.VALIDATED, reason="Career consistency checks passed")
+    assert cand.status == CandidateState.VALIDATED
+    assert len(cand.state_history) == 3
+
+    # 4. VALIDATED -> READY
+    cand.transition_to(CandidateState.READY, reason="Ready for reviewer queue")
+    assert cand.status == CandidateState.READY
+    assert len(cand.state_history) == 4
+
+    # 5. READY -> APPROVED (terminal)
+    cand.transition_to(CandidateState.APPROVED, reason="Admin approved", actor="admin_coppi")
+    assert cand.status == CandidateState.APPROVED
+    assert len(cand.state_history) == 5
+    assert cand.is_terminal() is True
+
+
+def test_legal_transitions_review_and_rejected():
+    cand = CandidatePlayer(
+        candidate_id="cand_test_player_2",
+        source="wiki",
+        source_id="Test_Player_2",
+    )
+    cand.transition_to(CandidateState.FETCHED)
+    # FETCHED -> REVIEW_REQUIRED
+    cand.transition_to(CandidateState.REVIEW_REQUIRED, reason="Ambiguous nationality detected")
+    assert cand.status == CandidateState.REVIEW_REQUIRED
+
+    # REVIEW_REQUIRED -> NORMALIZED (retry/reprocess normalization)
+    cand.transition_to(CandidateState.NORMALIZED, reason="Re-running normalization with override")
+    assert cand.status == CandidateState.NORMALIZED
+
+    # NORMALIZED -> REVIEW_REQUIRED
+    cand.transition_to(CandidateState.REVIEW_REQUIRED, reason="Still dubious")
+    assert cand.status == CandidateState.REVIEW_REQUIRED
+
+    # REVIEW_REQUIRED -> REJECTED (terminal)
+    cand.transition_to(CandidateState.REJECTED, reason="Confirmed duplicate of existing player")
+    assert cand.status == CandidateState.REJECTED
+    assert cand.is_terminal() is True
+
+
+def test_illegal_transitions_rejected():
+    cand = CandidatePlayer(
+        candidate_id="cand_illegal_test",
+        source="wiki",
+        source_id="P1",
+    )
+
+    # DISCOVERED non puo' saltare direttamente a VALIDATED, READY o APPROVED
+    invalid_targets = [
+        CandidateState.NORMALIZED,
+        CandidateState.VALIDATED,
+        CandidateState.REVIEW_REQUIRED,
+        CandidateState.READY,
+        CandidateState.APPROVED,
+    ]
+    for target in invalid_targets:
+        with pytest.raises(InvalidStateTransitionError) as exc_info:
+            cand.transition_to(target)
+        err = exc_info.value
+        assert err.candidate_id == "cand_illegal_test"
+        assert err.current_state == CandidateState.DISCOVERED
+        assert err.target_state == target
+        # Lo stato non deve essere mutato in caso di errore
+        assert cand.status == CandidateState.DISCOVERED
+        assert len(cand.state_history) == 0
+
+
+def test_terminal_states_cannot_transition():
+    # Test APPROVED terminal
+    cand_app = CandidatePlayer(candidate_id="cand_app", source="wiki", source_id="A1")
+    cand_app.transition_to(CandidateState.FETCHED)
+    cand_app.transition_to(CandidateState.NORMALIZED)
+    cand_app.transition_to(CandidateState.VALIDATED)
+    cand_app.transition_to(CandidateState.APPROVED)
+    assert cand_app.is_terminal() is True
+
+    for target in CandidateState:
+        with pytest.raises(InvalidStateTransitionError):
+            cand_app.transition_to(target)
+    assert cand_app.status == CandidateState.APPROVED
+
+    # Test REJECTED terminal
+    cand_rej = CandidatePlayer(candidate_id="cand_rej", source="wiki", source_id="R1")
+    cand_rej.transition_to(CandidateState.REJECTED)
+    assert cand_rej.is_terminal() is True
+
+    for target in CandidateState:
+        with pytest.raises(InvalidStateTransitionError):
+            cand_rej.transition_to(target)
+    assert cand_rej.status == CandidateState.REJECTED
+
+
+def test_error_recording_and_retry_tracking():
+    cand = CandidatePlayer(
+        candidate_id="cand_err_test",
+        source="wiki",
+        source_id="ErrPlayer",
+        max_retries=2,
+    )
+    assert cand.retry_count == 0
+    assert cand.can_retry() is True
+
+    # 1. Registra primo errore retryable
+    err1 = cand.record_error(
+        error_type="HTTP_TIMEOUT",
+        message="Request to wikipedia timed out",
+        details={"status_code": 504, "endpoint": "https://it.wikipedia.org/..."},
+        retryable=True,
+    )
+    assert isinstance(err1, CandidateError)
+    assert err1.error_type == "HTTP_TIMEOUT"
+    assert err1.state == CandidateState.DISCOVERED
+    assert cand.retry_count == 1
+    assert cand.last_error == err1
+    assert len(cand.errors) == 1
+    assert cand.can_retry() is True
+
+    # 2. Registra secondo errore
+    err2 = cand.record_error(
+        error_type="HTTP_500",
+        message="Internal server error on source",
+        retryable=True,
+    )
+    assert cand.retry_count == 2
+    assert cand.last_error == err2
+    assert len(cand.errors) == 2
+    # Raggiunta la soglia massima: can_retry deve essere False
+    assert cand.can_retry() is False
+
+    # 3. Errore non retryable non incrementa retry_count
+    err3 = cand.record_error(
+        error_type="PARSE_FATAL",
+        message="HTML is corrupt",
+        retryable=False,
+    )
+    assert cand.retry_count == 2
+    assert len(cand.errors) == 3
+    assert err3.retryable is False
+
+    # 4. Reset dei retry
+    cand.reset_retries()
+    assert cand.retry_count == 0
+    assert cand.can_retry() is True
+
+
+def test_serialization_round_trip():
+    cand = CandidatePlayer(
+        candidate_id="cand_messi_test",
+        source="wikipedia",
+        source_id="Lionel_Messi",
+        full_name="Lionel Messi",
+        aliases=["messi", "leo messi"],
+        nationality="Argentina",
+        position="Attaccante",
+        birth_year=1987,
+        popularity=5,
+        career=[
+            {"team": "Barcelona", "country": "Spagna", "league": "La Liga", "start_year": 2004, "end_year": 2021},
+            {"team": "PSG", "country": "Francia", "league": "Ligue 1", "start_year": 2021, "end_year": 2023},
+        ],
+        raw_data={"infobox_title": "Lionel Andrés Messi Cuccittini"},
+        validation_warnings=["Club 'PSG' normalized to 'Paris Saint-Germain'"],
+        validation_errors=[],
+        confidence_score=0.98,
+        metadata={"tags": ["legend", "ballon_dor"]},
+    )
+    cand.transition_to(CandidateState.FETCHED, reason="Fetched")
+    cand.record_error(error_type="MINOR_WARNING", message="Slow response", retryable=False)
+
+    data = cand.to_dict()
+    # Verifica che sia JSON serializzabile
+    json_str = json.dumps(data, indent=2)
+    loaded_data = json.loads(json_str)
+
+    restored = CandidatePlayer.from_dict(loaded_data)
+
+    assert restored.candidate_id == cand.candidate_id
+    assert restored.source == cand.source
+    assert restored.source_id == cand.source_id
+    assert restored.status == cand.status
+    assert restored.full_name == cand.full_name
+    assert restored.aliases == cand.aliases
+    assert restored.nationality == cand.nationality
+    assert restored.birth_year == cand.birth_year
+    assert restored.career == cand.career
+    assert restored.raw_data == cand.raw_data
+    assert restored.validation_warnings == cand.validation_warnings
+    assert restored.confidence_score == cand.confidence_score
+    assert len(restored.state_history) == 1
+    assert restored.state_history[0].from_state == CandidateState.DISCOVERED
+    assert restored.state_history[0].to_state == CandidateState.FETCHED
+    assert len(restored.errors) == 1
+    assert restored.errors[0].error_type == "MINOR_WARNING"
+    assert restored.metadata == cand.metadata

--- a/tests/test_candidate_player.py
+++ b/tests/test_candidate_player.py
@@ -1,5 +1,6 @@
 """Unit tests for Candidate Player domain model, states, transitions, errors, and IDs."""
 import json
+import re
 
 import pytest
 
@@ -47,24 +48,85 @@ def test_candidate_creation_validation():
         CandidatePlayer(candidate_id="cand_1", source="wiki", source_id="")
 
 
+def test_status_immutability_and_protection():
+    """Verifica che lo stato del ciclo di vita non sia mutabile direttamente
+    e che non possa essere impostato arbitrariamente tramite costruttore standard."""
+    cand = CandidatePlayer(candidate_id="cand_protect", source="wiki", source_id="1")
+    assert cand.status == CandidateState.DISCOVERED
+
+    # 1. Tentativo di mutazione diretta di status solleva AttributeError
+    with pytest.raises(AttributeError, match="Lo stato del candidato non puo' essere modificato direttamente"):
+        cand.status = CandidateState.APPROVED  # type: ignore[misc]
+    assert cand.status == CandidateState.DISCOVERED
+
+    # 2. Tentativo di passare 'status' al costruttore pubblico solleva TypeError
+    with pytest.raises(TypeError, match="unexpected keyword argument 'status'"):
+        CandidatePlayer(  # type: ignore[call-arg]
+            candidate_id="cand_bypass",
+            source="wiki",
+            source_id="2",
+            status=CandidateState.APPROVED,
+        )
+
+    # 3. Solo transition_to() puo' avanzare lo stato attraverso il grafo validato
+    cand.transition_to(CandidateState.FETCHED)
+    assert cand.status == CandidateState.FETCHED
+
+    # 4. Deserializzazione da persistenza (from_dict) ripristina lo stato corretto
+    restored = CandidatePlayer.from_dict({
+        "candidate_id": "cand_restored",
+        "source": "wiki",
+        "source_id": "3",
+        "status": CandidateState.VALIDATED.value,
+    })
+    assert restored.status == CandidateState.VALIDATED
+
+
 def test_deterministic_id_generation():
     id1 = make_candidate_id("wikipedia", "Francesco Totti")
-    id2 = make_candidate_id("WIKIPEDIA", "francesco totti")
-    id3 = make_candidate_id("  Wikipedia  ", "Francesco   Totti  ")
+    id2 = make_candidate_id("wikipedia", "Francesco Totti")
 
-    assert id1 == "cand_wikipedia_francesco_totti"
-    assert id1 == id2 == id3
+    # Deterministico: chiamate identiche restituiscono l'ID identico
+    assert id1 == id2
+    assert id1.startswith("cand_wikipedia_francesco_totti_")
+
+    # Sicuro per filesystem e URL: solo caratteri alfanumerici e underscore
+    assert re.fullmatch(r"cand_[a-z0-9_]+", id1) is not None
 
     # Accenti e caratteri speciali
     id_accent = make_candidate_id("wikipedia", "Pelé")
-    assert id_accent == "cand_wikipedia_pele"
+    assert id_accent.startswith("cand_wikipedia_pele_")
 
     id_apostrophe = make_candidate_id("wiki", "N'Golo Kanté")
-    assert id_apostrophe == "cand_wiki_n_golo_kante"
+    assert id_apostrophe.startswith("cand_wiki_n_golo_kante_")
 
     # Wikidata Q-ID
     id_wd = make_candidate_id("wikidata", "Q1853")
-    assert id_wd == "cand_wikidata_q1853"
+    assert id_wd.startswith("cand_wikidata_q1853_")
+
+
+def test_deterministic_id_collision_resistance():
+    """Verifica che identificatori grezzi distinti (che prima collassavano allo stesso slug)
+    producano candidate_id distinti grazie all'hash crittografico stabile."""
+    id_dash = make_candidate_id("wiki", "A-B")
+    id_slash = make_candidate_id("wiki", "A/B")
+    id_underscore = make_candidate_id("wiki", "A_B")
+    id_space = make_candidate_id("wiki", "A B")
+
+    # Devono essere tutti e 4 distinti
+    unique_ids = {id_dash, id_slash, id_underscore, id_space}
+    assert len(unique_ids) == 4, f"Collisione rilevata tra identificatori distinti: {unique_ids}"
+
+    # Tutti mantengono lo slug leggibile come prefisso
+    assert id_dash.startswith("cand_wiki_a_b_")
+    assert id_slash.startswith("cand_wiki_a_b_")
+    assert id_underscore.startswith("cand_wiki_a_b_")
+    assert id_space.startswith("cand_wiki_a_b_")
+
+    # Anche la sorgente differenzia l'ID
+    id_wiki = make_candidate_id("wikipedia", "player_1")
+    id_wd = make_candidate_id("wikidata", "player_1")
+    assert id_wiki != id_wd
 
 
 def test_deterministic_id_invalid_inputs():
@@ -76,12 +138,17 @@ def test_deterministic_id_invalid_inputs():
 
 def test_deterministic_id_from_name():
     id1 = make_candidate_id_from_name("Lionel Messi", 1987)
-    id2 = make_candidate_id_from_name("lionel messi", 1987)
-    assert id1 == "cand_lionel_messi_1987"
+    id2 = make_candidate_id_from_name("Lionel Messi", 1987)
     assert id1 == id2
+    assert id1.startswith("cand_lionel_messi_1987_")
 
     id_no_year = make_candidate_id_from_name("Zinedine Zidane")
-    assert id_no_year == "cand_zinedine_zidane"
+    assert id_no_year.startswith("cand_zinedine_zidane_")
+
+    # Collision resistance on names with hyphens vs spaces
+    id_hyphen = make_candidate_id_from_name("Jean-Pierre Papin", 1963)
+    id_space = make_candidate_id_from_name("Jean Pierre Papin", 1963)
+    assert id_hyphen != id_space
 
     with pytest.raises(ValueError, match="full_name deve essere una stringa valida"):
         make_candidate_id_from_name("   ")

--- a/tests/test_candidate_repository.py
+++ b/tests/test_candidate_repository.py
@@ -1,0 +1,279 @@
+"""Unit tests for CandidatePlayerRepository implementations (in-memory and file-backed)
+and critical isolation guards protecting data/players.json.
+"""
+import hashlib
+import json
+from pathlib import Path
+
+import pytest
+
+from services.candidate_player import CandidatePlayer, CandidateState
+from services.repos.candidates import (
+    CandidateRepositoryError,
+    FileCandidatePlayerRepository,
+    InMemoryCandidatePlayerRepository,
+)
+
+
+@pytest.fixture
+def sample_candidate() -> CandidatePlayer:
+    return CandidatePlayer(
+        candidate_id="cand_wiki_del_piero",
+        source="wikipedia",
+        source_id="Alessandro_Del_Piero",
+        full_name="Alessandro Del Piero",
+        aliases=["del piero", "alessandro del piero", "pinturicchio"],
+        nationality="Italia",
+        position="Attaccante",
+        birth_year=1974,
+        popularity=5,
+        career=[
+            {"team": "Padova", "country": "Italia", "league": "Serie B", "start_year": 1991, "end_year": 1993},
+            {"team": "Juventus", "country": "Italia", "league": "Serie A", "start_year": 1993, "end_year": 2012},
+        ],
+    )
+
+
+# ---------------------------------------------------------------------------
+# Test InMemoryCandidatePlayerRepository
+# ---------------------------------------------------------------------------
+
+
+def test_in_memory_repository_crud(sample_candidate: CandidatePlayer):
+    repo = InMemoryCandidatePlayerRepository()
+    assert repo.count() == 0
+    assert repo.get_by_id(sample_candidate.candidate_id) is None
+    assert repo.exists(sample_candidate.candidate_id) is False
+
+    # Save
+    repo.save(sample_candidate)
+    assert repo.count() == 1
+    assert repo.exists(sample_candidate.candidate_id) is True
+
+    # Get by ID
+    loaded = repo.get_by_id(sample_candidate.candidate_id)
+    assert loaded is not None
+    assert loaded.candidate_id == sample_candidate.candidate_id
+    assert loaded.full_name == "Alessandro Del Piero"
+
+    # Isolamento da modifiche dirette all'oggetto in-memory
+    loaded.full_name = "Modified Del Piero"
+    fresh_loaded = repo.get_by_id(sample_candidate.candidate_id)
+    assert fresh_loaded is not None
+    assert fresh_loaded.full_name == "Alessandro Del Piero"
+
+    # Delete
+    assert repo.delete(sample_candidate.candidate_id) is True
+    assert repo.count() == 0
+    assert repo.get_by_id(sample_candidate.candidate_id) is None
+    assert repo.delete(sample_candidate.candidate_id) is False
+
+
+def test_in_memory_repository_filtering_and_pagination():
+    repo = InMemoryCandidatePlayerRepository()
+
+    c1 = CandidatePlayer(candidate_id="cand_1", source="wiki", source_id="1", status=CandidateState.DISCOVERED)
+    c2 = CandidatePlayer(candidate_id="cand_2", source="wiki", source_id="2", status=CandidateState.FETCHED)
+    c3 = CandidatePlayer(candidate_id="cand_3", source="wiki", source_id="3", status=CandidateState.FETCHED)
+    c4 = CandidatePlayer(candidate_id="cand_4", source="wiki", source_id="4", status=CandidateState.READY)
+
+    for c in (c1, c2, c3, c4):
+        repo.save(c)
+
+    assert repo.count() == 4
+    assert repo.count(CandidateState.FETCHED) == 2
+    assert repo.count(CandidateState.READY) == 1
+    assert repo.count(CandidateState.APPROVED) == 0
+
+    # List all con ordinamento e paginazione
+    all_cand = repo.list_all()
+    assert [c.candidate_id for c in all_cand] == ["cand_1", "cand_2", "cand_3", "cand_4"]
+
+    paginated = repo.list_all(limit=2, offset=1)
+    assert [c.candidate_id for c in paginated] == ["cand_2", "cand_3"]
+
+    # Filter by state
+    fetched = repo.find_by_state(CandidateState.FETCHED)
+    assert [c.candidate_id for c in fetched] == ["cand_2", "cand_3"]
+
+    ready = repo.find_by_state(CandidateState.READY)
+    assert len(ready) == 1
+    assert ready[0].candidate_id == "cand_4"
+
+
+# ---------------------------------------------------------------------------
+# Test FileCandidatePlayerRepository
+# ---------------------------------------------------------------------------
+
+
+def test_file_repository_crud(tmp_path: Path, sample_candidate: CandidatePlayer):
+    storage_dir = tmp_path / "candidates"
+    repo = FileCandidatePlayerRepository(storage_dir=storage_dir)
+
+    assert repo.count() == 0
+    assert repo.exists(sample_candidate.candidate_id) is False
+    assert repo.get_by_id(sample_candidate.candidate_id) is None
+
+    # Save
+    repo.save(sample_candidate)
+    assert repo.count() == 1
+    assert repo.exists(sample_candidate.candidate_id) is True
+
+    # Verifica che il file esista su disco con formato JSON valido
+    expected_file = storage_dir / f"{sample_candidate.candidate_id}.json"
+    assert expected_file.is_file()
+    with open(expected_file, "r", encoding="utf-8") as f:
+        raw_json = json.load(f)
+    assert raw_json["candidate_id"] == sample_candidate.candidate_id
+    assert raw_json["full_name"] == "Alessandro Del Piero"
+
+    # Get by ID (round-trip da disco)
+    loaded = repo.get_by_id(sample_candidate.candidate_id)
+    assert loaded is not None
+    assert loaded.candidate_id == sample_candidate.candidate_id
+    assert loaded.full_name == sample_candidate.full_name
+    assert loaded.career == sample_candidate.career
+    assert loaded.status == CandidateState.DISCOVERED
+
+    # Aggiornamento dello stato e ri-salvataggio
+    loaded.transition_to(CandidateState.FETCHED, reason="Fetched career")
+    repo.save(loaded)
+
+    reloaded = repo.get_by_id(sample_candidate.candidate_id)
+    assert reloaded is not None
+    assert reloaded.status == CandidateState.FETCHED
+    assert len(reloaded.state_history) == 1
+    assert reloaded.state_history[0].to_state == CandidateState.FETCHED
+
+    # Delete
+    assert repo.delete(sample_candidate.candidate_id) is True
+    assert not expected_file.exists()
+    assert repo.count() == 0
+    assert repo.get_by_id(sample_candidate.candidate_id) is None
+    assert repo.delete(sample_candidate.candidate_id) is False
+
+
+def test_file_repository_atomic_write(tmp_path: Path, sample_candidate: CandidatePlayer):
+    storage_dir = tmp_path / "atomic_candidates"
+    repo = FileCandidatePlayerRepository(storage_dir=storage_dir)
+    repo.save(sample_candidate)
+
+    # Verifica che non rimangano file temporanei .tmp_ nella cartella
+    tmp_files = list(storage_dir.glob(".tmp_*"))
+    assert tmp_files == []
+
+
+def test_file_repository_path_traversal_protection(tmp_path: Path):
+    repo = FileCandidatePlayerRepository(storage_dir=tmp_path)
+    with pytest.raises(ValueError, match="candidate_id non valido per il filesystem"):
+        repo.save(CandidatePlayer(candidate_id="../hacked", source="w", source_id="1"))
+
+    with pytest.raises(ValueError, match="candidate_id non valido per il filesystem"):
+        repo.get_by_id("../../etc/passwd")
+
+
+def test_file_repository_filtering_and_counts(tmp_path: Path):
+    repo = FileCandidatePlayerRepository(storage_dir=tmp_path / "pool")
+
+    p1 = CandidatePlayer(candidate_id="cand_a", source="w", source_id="1", status=CandidateState.DISCOVERED)
+    p2 = CandidatePlayer(candidate_id="cand_b", source="w", source_id="2", status=CandidateState.FETCHED)
+    p3 = CandidatePlayer(candidate_id="cand_c", source="w", source_id="3", status=CandidateState.FETCHED)
+    p4 = CandidatePlayer(candidate_id="cand_d", source="w", source_id="4", status=CandidateState.REVIEW_REQUIRED)
+
+    for p in (p1, p2, p3, p4):
+        repo.save(p)
+
+    assert repo.count() == 4
+    assert repo.count(CandidateState.DISCOVERED) == 1
+    assert repo.count(CandidateState.FETCHED) == 2
+    assert repo.count(CandidateState.REVIEW_REQUIRED) == 1
+    assert repo.count(CandidateState.APPROVED) == 0
+
+    fetched = repo.find_by_state(CandidateState.FETCHED)
+    assert len(fetched) == 2
+    assert [c.candidate_id for c in fetched] == ["cand_b", "cand_c"]
+
+
+# ---------------------------------------------------------------------------
+# Critical Safety & Dataset Isolation Tests
+# ---------------------------------------------------------------------------
+
+
+def test_safety_guard_rejects_targeting_production_dataset(tmp_path: Path):
+    """Verifica che il repository rifiuti categoricamente di essere inizializzato
+    su percorsi coincidenti con data/players.json."""
+    base_dir = Path(__file__).resolve().parents[1]
+    prod_path = base_dir / "data" / "players.json"
+
+    # Tentativo esplicito di puntare a data/players.json come storage
+    with pytest.raises(CandidateRepositoryError, match="Violazione di sicurezza"):
+        FileCandidatePlayerRepository(storage_dir=prod_path)
+
+    # Tentativo di usare una cartella chiamata 'players.json'
+    fake_prod = tmp_path / "players.json"
+    with pytest.raises(CandidateRepositoryError, match="Violazione di sicurezza"):
+        FileCandidatePlayerRepository(storage_dir=fake_prod)
+
+
+def test_safety_production_dataset_never_modified(tmp_path: Path, sample_candidate: CandidatePlayer):
+    """Test di invariante assoluto: durante tutte le operazioni di salvataggio,
+    transizione, aggiornamento e cancellazione di candidati, il file di produzione
+    data/players.json NON subisce alcuna modifica."""
+    base_dir = Path(__file__).resolve().parents[1]
+    prod_file = base_dir / "data" / "players.json"
+    assert prod_file.exists(), f"File di produzione non trovato a {prod_file}"
+
+    # 1. Calcola hash e metadati prima dell'esecuzione
+    with open(prod_file, "rb") as f:
+        content_before = f.read()
+    hash_before = hashlib.sha256(content_before).hexdigest()
+    mtime_before = prod_file.stat().st_mtime_ns
+    size_before = prod_file.stat().st_size
+
+    # 2. Esegui ciclo completo su candidato con FileCandidatePlayerRepository
+    repo = FileCandidatePlayerRepository(storage_dir=tmp_path / "candidates_sandbox")
+    repo.save(sample_candidate)
+
+    loaded = repo.get_by_id(sample_candidate.candidate_id)
+    assert loaded is not None
+    loaded.transition_to(CandidateState.FETCHED)
+    loaded.transition_to(CandidateState.NORMALIZED)
+    loaded.transition_to(CandidateState.VALIDATED)
+    loaded.transition_to(CandidateState.READY)
+    loaded.transition_to(CandidateState.APPROVED)
+    repo.save(loaded)
+
+    all_cand = repo.list_all()
+    assert len(all_cand) == 1
+    repo.delete(sample_candidate.candidate_id)
+
+    # 3. Verifica invariante sul file di produzione
+    with open(prod_file, "rb") as f:
+        content_after = f.read()
+    hash_after = hashlib.sha256(content_after).hexdigest()
+    mtime_after = prod_file.stat().st_mtime_ns
+    size_after = prod_file.stat().st_size
+
+    assert hash_before == hash_after, "CRITICO: hash di data/players.json e' cambiato!"
+    assert size_before == size_after, "CRITICO: dimensione di data/players.json e' cambiata!"
+    assert mtime_before == mtime_after, "CRITICO: timestamp mtime di data/players.json e' cambiato!"
+
+
+def test_no_automatic_promotion_to_player_pool(tmp_path: Path, sample_candidate: CandidatePlayer):
+    """Verifica che l'approvazione di un candidato NON lo inserisca automaticamente
+    nel pool dei giocatori utilizzabili dal gioco."""
+    from services.player_pool import _load_raw_players
+
+    repo = FileCandidatePlayerRepository(storage_dir=tmp_path / "candidates_sandbox")
+    sample_candidate.transition_to(CandidateState.FETCHED)
+    sample_candidate.transition_to(CandidateState.NORMALIZED)
+    sample_candidate.transition_to(CandidateState.VALIDATED)
+    sample_candidate.transition_to(CandidateState.APPROVED)
+    repo.save(sample_candidate)
+
+    raw_players = _load_raw_players()
+    existing_ids = {p.get("id") for p in raw_players}
+
+    # Il candidate_id non deve mai apparire tra gli ID del pool di gioco
+    assert sample_candidate.candidate_id not in existing_ids
+    assert "cand_wiki_del_piero" not in existing_ids

--- a/tests/test_candidate_repository.py
+++ b/tests/test_candidate_repository.py
@@ -72,10 +72,16 @@ def test_in_memory_repository_crud(sample_candidate: CandidatePlayer):
 def test_in_memory_repository_filtering_and_pagination():
     repo = InMemoryCandidatePlayerRepository()
 
-    c1 = CandidatePlayer(candidate_id="cand_1", source="wiki", source_id="1", status=CandidateState.DISCOVERED)
-    c2 = CandidatePlayer(candidate_id="cand_2", source="wiki", source_id="2", status=CandidateState.FETCHED)
-    c3 = CandidatePlayer(candidate_id="cand_3", source="wiki", source_id="3", status=CandidateState.FETCHED)
-    c4 = CandidatePlayer(candidate_id="cand_4", source="wiki", source_id="4", status=CandidateState.READY)
+    c1 = CandidatePlayer(candidate_id="cand_1", source="wiki", source_id="1")
+    c2 = CandidatePlayer(candidate_id="cand_2", source="wiki", source_id="2")
+    c2.transition_to(CandidateState.FETCHED)
+    c3 = CandidatePlayer(candidate_id="cand_3", source="wiki", source_id="3")
+    c3.transition_to(CandidateState.FETCHED)
+    c4 = CandidatePlayer(candidate_id="cand_4", source="wiki", source_id="4")
+    c4.transition_to(CandidateState.FETCHED)
+    c4.transition_to(CandidateState.NORMALIZED)
+    c4.transition_to(CandidateState.VALIDATED)
+    c4.transition_to(CandidateState.READY)
 
     for c in (c1, c2, c3, c4):
         repo.save(c)
@@ -175,10 +181,14 @@ def test_file_repository_path_traversal_protection(tmp_path: Path):
 def test_file_repository_filtering_and_counts(tmp_path: Path):
     repo = FileCandidatePlayerRepository(storage_dir=tmp_path / "pool")
 
-    p1 = CandidatePlayer(candidate_id="cand_a", source="w", source_id="1", status=CandidateState.DISCOVERED)
-    p2 = CandidatePlayer(candidate_id="cand_b", source="w", source_id="2", status=CandidateState.FETCHED)
-    p3 = CandidatePlayer(candidate_id="cand_c", source="w", source_id="3", status=CandidateState.FETCHED)
-    p4 = CandidatePlayer(candidate_id="cand_d", source="w", source_id="4", status=CandidateState.REVIEW_REQUIRED)
+    p1 = CandidatePlayer(candidate_id="cand_a", source="w", source_id="1")
+    p2 = CandidatePlayer(candidate_id="cand_b", source="w", source_id="2")
+    p2.transition_to(CandidateState.FETCHED)
+    p3 = CandidatePlayer(candidate_id="cand_c", source="w", source_id="3")
+    p3.transition_to(CandidateState.FETCHED)
+    p4 = CandidatePlayer(candidate_id="cand_d", source="w", source_id="4")
+    p4.transition_to(CandidateState.FETCHED)
+    p4.transition_to(CandidateState.REVIEW_REQUIRED)
 
     for p in (p1, p2, p3, p4):
         repo.save(p)


### PR DESCRIPTION
### Summary
This PR implements the Candidate Player Core foundation for the ingestion pipeline (sub-issue of epic #13, resolving #54). It provides the `CandidatePlayer` domain model, deterministic candidate identifier generation, finite state machine across all 8 lifecycle states with explicit transition guards, structured error and retry tracking, and an isolated repository abstraction with file-backed persistence physically separated from the production dataset.

Closes #54

### Domain model
- **`CandidatePlayer`** (`services/candidate_player.py`): Encapsulates candidate identity (`candidate_id`, `source`, `source_id`), lifecycle state, timestamps (`created_at`, `updated_at`, `last_transition_at`), transition audit trail (`state_history`), player data payload (`full_name`, `aliases`, `nationality`, `position`, `birth_year`, `popularity`, `career`, `raw_data`, `metadata`), quality hooks (`validation_warnings`, `validation_errors`, `confidence_score`), and error/retry tracking (`errors`, `last_error`, `retry_count`, `max_retries`).
- **Deterministic ID Generation**:
  - `make_candidate_id(source, source_id)`: Generates normalized, URL-safe identifiers prefixed with `cand_{source}_{source_id}` (e.g. `cand_wikipedia_francesco_totti`, `cand_wikidata_q1853`).
  - `make_candidate_id_from_name(full_name, birth_year)`: Generates normalized identifiers from player name and optional birth year.
- **Serialization**: `to_dict()` and `from_dict()` ensure lossless, deterministic JSON serialization and deserialization.

### State machine
- **States**: `DISCOVERED`, `FETCHED`, `NORMALIZED`, `VALIDATED`, `REVIEW_REQUIRED`, `READY`, `APPROVED`, `REJECTED`.
- **Allowed Transitions**:
  - `DISCOVERED` → `FETCHED`, `REJECTED`
  - `FETCHED` → `NORMALIZED`, `REVIEW_REQUIRED`, `REJECTED`
  - `NORMALIZED` → `VALIDATED`, `REVIEW_REQUIRED`, `REJECTED`
  - `VALIDATED` → `READY`, `REVIEW_REQUIRED`, `APPROVED`, `REJECTED`
  - `REVIEW_REQUIRED` → `READY`, `APPROVED`, `REJECTED`, `FETCHED`, `NORMALIZED` (supports reviewer requesting re-fetch/re-normalization)
  - `READY` → `APPROVED`, `REJECTED`, `REVIEW_REQUIRED`
- **Terminal States**: `APPROVED` and `REJECTED` are deliberately terminal (no further transitions permitted), preserving audit integrity and preventing accidental resurrection or reprocessing of finalized records.
- **Enforcement**: Any illegal transition raises `InvalidStateTransitionError` and leaves candidate state unmodified.
- **Auditability**: Every successful transition appends a `StateTransitionRecord` with `from_state`, `to_state`, UTC ISO timestamp, optional reason, actor, and metadata.

### Persistence
- **`CandidatePlayerRepository`** (`services/repos/candidates.py`): Abstract base class defining `save`, `get_by_id`, `exists`, `list_all`, `find_by_state`, `count`, and `delete`.
- **`InMemoryCandidatePlayerRepository`**: Fast, thread-safe in-memory repository for unit testing and isolated pipelines.
- **`FileCandidatePlayerRepository`**: Isolated file-backed repository saving individual JSON files per candidate (`<storage_dir>/<candidate_id>.json`) with atomic write (temporary file + atomic `os.replace`).
- **Querying & Filtering**: Implements `find_by_state(state)` with limit and offset support.

### Safety / production dataset isolation
- **Zero Production Mutation**: Candidate persistence is physically decoupled from `data/players.json`.
- **Safety Guards**: `FileCandidatePlayerRepository` explicitly rejects any initialization targeting `data/players.json` or files named `players.json`.
- **Git Isolation**: `data/candidates/` and `.worktrees/` added to `.gitignore`.
- **No Automatic Promotion**: Candidate records are isolated in the candidate storage domain; no promotion logic to production exists in this core PR.
- **Invariant Tests**: Automated test explicitly asserts that SHA-256 hash, size, and modification timestamp of `data/players.json` are unchanged before and after full candidate lifecycle operations.

### Tests
Added 20 focused automated unit tests:
- `tests/test_candidate_player.py` (11 tests): candidate creation, deterministic IDs, accents/character cleaning, happy path lifecycle, review/rejection paths, illegal transition rejection, terminal state immutability, error recording, retry threshold and reset, JSON round-trip fidelity.
- `tests/test_candidate_repository.py` (9 tests): CRUD operations, pagination, state filtering, atomic writes, path traversal guards, safety guard against targeting production files, strict `data/players.json` invariant check, and absence of automatic promotion.

### Validation performed
Executed locally via `tools.dev` in the dedicated worktree:
- `pytest tests/test_candidate_player.py tests/test_candidate_repository.py -v`: 20/20 passed in 0.27s.
- `pytest tests/test_player_pool.py tests/test_dataset_integrity.py tests/test_dataset_editor.py tests/test_import_players.py -q`: 61/61 passed in 0.42s.
- `python -m tools.dev lint` (Ruff): All checks passed.
- `python -m tools.dev typecheck` (Mypy on `services/`): Success (0 issues across 53 source files).
- `python -m tools.dev dataset-check` (Strict dataset report): Passed, 650 valid players.
- `python -m tools.dev check` (Full local suite): All steps passed (Environment, Syntax, Lint, Typecheck, Dataset, Node client tests, Pytest 963 passed).
- Confirmed SHA-256 of `data/players.json` remained identical throughout (`04a708621d95954f6882d6e349912a4d415b404948f27f3df5b3b35cb62ca345`).

### Limitations
- Does not connect to external data sources (deferred to #14).
- Does not perform automated club name normalization or career gap analysis (deferred to #26).
- Does not expose an administrative review UI (deferred to #15 / #35).

### Risk
- **Low**: Pure additive domain and repository modules. No existing runtime paths, bot handlers, or game services are modified. Production player data is completely untouched.

### Roadmap impact
- **#14 (Multi-source adapters)**: Can instantiate `CandidatePlayer` with `make_candidate_id(source, source_id)`, transition from `DISCOVERED` to `FETCHED`, populate `raw_data`, and record errors/retries using `record_error()` upon network or parsing failures.
- **#26 (Normalization & Validation)**: Can ingest `FETCHED` candidates, execute normalization routines transitioning to `NORMALIZED`, run career validation rules transitioning to `VALIDATED` or `REVIEW_REQUIRED`, and record structured warnings in `validation_warnings`.
- **#15 (Review Queue)**: Can query `repo.find_by_state(CandidateState.REVIEW_REQUIRED)` and `repo.find_by_state(CandidateState.READY)` to present candidates to administrators, executing transitions to `APPROVED` or `REJECTED`.
