### PR TITLE
feat(players): multi-source player-data adapters (#14)

### DIFF
--- a/services/adapters/__init__.py
+++ b/services/adapters/__init__.py
@@ -11,6 +11,7 @@ from services.adapters.base import (
     AdapterError,
     AdapterErrorType,
     AdapterResult,
+    AdapterSearchResult,
     CareerEntry,
     PlayerSourceAdapter,
 )
@@ -31,6 +32,7 @@ __all__ = [
     "AdapterError",
     "AdapterErrorType",
     "AdapterResult",
+    "AdapterSearchResult",
     "CareerEntry",
     "HttpClient",
     "HttpError",

--- a/services/adapters/__init__.py
+++ b/services/adapters/__init__.py
@@ -1,0 +1,44 @@
+"""Multi-source player-data adapter layer.
+
+Provides a modular, testable adapter contract for external player data
+acquisition that feeds into the Candidate Player pipeline (#54).
+
+Adapters produce source-neutral results that can populate CandidatePlayer
+models without directly modifying the production dataset.
+"""
+
+from services.adapters.base import (
+    AdapterError,
+    AdapterErrorType,
+    AdapterResult,
+    CareerEntry,
+    PlayerSourceAdapter,
+)
+from services.adapters.candidate_integration import (
+    populate_candidate_from_result,
+    record_adapter_failure,
+)
+from services.adapters.http_client import (
+    HttpClient,
+    HttpError,
+    HttpResponse,
+    UrllibHttpClient,
+)
+from services.adapters.wikidata import WikidataAdapter
+from services.adapters.wikipedia import WikipediaAdapter
+
+__all__ = [
+    "AdapterError",
+    "AdapterErrorType",
+    "AdapterResult",
+    "CareerEntry",
+    "HttpClient",
+    "HttpError",
+    "HttpResponse",
+    "PlayerSourceAdapter",
+    "UrllibHttpClient",
+    "WikidataAdapter",
+    "WikipediaAdapter",
+    "populate_candidate_from_result",
+    "record_adapter_failure",
+]

--- a/services/adapters/base.py
+++ b/services/adapters/base.py
@@ -140,6 +140,37 @@ class AdapterResult:
         }
 
 
+@dataclass
+class AdapterSearchResult:
+    """Result container for search operations across adapters.
+
+    Distinguishes genuine empty results (success=True, identifiers=[]) from
+    failures (success=False, errors=[...]).
+
+    Attributes:
+        source_name: Canonical name of the source (e.g. "wikipedia", "wikidata").
+        query: Search query string that was executed.
+        identifiers: List of source-specific identifiers found (empty if none or on failure).
+        success: True when search completed normally (even with 0 results); False on failure.
+        errors: Structured errors if the search failed or encountered issues.
+    """
+
+    source_name: str
+    query: str
+    identifiers: list[str] = field(default_factory=list)
+    success: bool = True
+    errors: list[AdapterError] = field(default_factory=list)
+
+    def to_dict(self) -> dict[str, Any]:
+        return {
+            "source_name": self.source_name,
+            "query": self.query,
+            "identifiers": list(self.identifiers),
+            "success": self.success,
+            "errors": [e.to_dict() for e in self.errors],
+        }
+
+
 class PlayerSourceAdapter(abc.ABC):
     """Abstract contract that every player data source must implement.
 
@@ -173,18 +204,18 @@ class PlayerSourceAdapter(abc.ABC):
         ...
 
     @abc.abstractmethod
-    def search_player(self, query: str, limit: int = 5) -> list[str]:
+    def search_player(self, query: str, limit: int = 5) -> AdapterSearchResult:
         """Search for player identifiers matching a free-text query.
 
-        Returns up to ``limit`` source-specific identifiers.  On error returns
-        an empty list rather than raising (search is best-effort).
+        Returns an ``AdapterSearchResult`` allowing callers to distinguish between
+        a successful empty search result and transport/parse failures.
 
         Args:
             query: Free-text search query (player name, nickname, ...).
             limit: Maximum number of identifiers to return.
 
         Returns:
-            List of source-specific identifiers found.
+            An ``AdapterSearchResult`` with found identifiers and/or structured errors.
         """
         ...
 

--- a/services/adapters/base.py
+++ b/services/adapters/base.py
@@ -1,0 +1,194 @@
+"""Adapter contract: abstract base, result types, and structured errors.
+
+Defines the source-neutral interface that every player data source must
+implement, plus the data structures that carry results and failures through
+the pipeline.
+
+Design principles:
+- One failing source must NOT corrupt data obtained from another source.
+- Adapters expose structured failures for upstream retry/review decisions.
+- No silent swallowing of HTTP or parsing errors.
+- Raw source payloads are preserved for downstream normalization (#26)
+  and provenance (#27).
+"""
+from __future__ import annotations
+
+import abc
+import copy
+from dataclasses import dataclass, field
+from datetime import datetime, timezone
+from enum import Enum
+from typing import Any, Optional, TypedDict
+
+
+class AdapterErrorType(str, Enum):
+    """Categorizzazione strutturata degli errori dell'adapter."""
+
+    TRANSPORT = "transport"        # HTTP / network-level failure
+    PARSE = "parse"                # Source returned data but parser failed
+    NOT_FOUND = "not_found"        # Source record does not exist
+    TIMEOUT = "timeout"            # Request timed out
+    RATE_LIMIT = "rate_limit"      # 429 or equivalent throttling
+    UNKNOWN = "unknown"            # Catch-all for unexpected errors
+
+
+@dataclass
+class AdapterError:
+    """Structured failure from an adapter, suitable for logging and retry decisions.
+
+    Attributes:
+        error_type: Categorised cause (transport, parse, not_found, ...).
+        message: Human-readable description.
+        source_name: Which adapter produced this error.
+        details: Free-form key/value metadata (HTTP status, URL, stack trace, ...).
+        retryable: Hint for orchestration — True means a retry *might* succeed.
+    """
+
+    error_type: AdapterErrorType
+    message: str
+    source_name: str
+    details: dict[str, Any] = field(default_factory=dict)
+    retryable: bool = True
+
+    def to_dict(self) -> dict[str, Any]:
+        return {
+            "error_type": self.error_type.value,
+            "message": self.message,
+            "source_name": self.source_name,
+            "details": copy.deepcopy(self.details),
+            "retryable": self.retryable,
+        }
+
+
+class CareerEntry(TypedDict, total=False):
+    """A single career stop as extracted by a source adapter.
+
+    All fields are optional (total=False) because different sources provide
+    different subsets.  The adapter should populate whatever the source gives
+    and leave the rest absent — downstream normalization (#26) handles gaps.
+    """
+
+    team: str
+    country: str
+    league: str
+    start_year: Optional[int]
+    end_year: Optional[int]
+    apps: Optional[int]
+    goals: Optional[int]
+    loan: bool
+    link: Optional[str]   # Wiki link target for club resolution
+
+
+@dataclass
+class AdapterResult:
+    """Source-neutral result container returned by every adapter.
+
+    Success is defined by ``success=True`` AND at least ``player_name`` being
+    populated.  An adapter may still succeed with partial data (some fields
+    ``None``) — the pipeline decides later whether partial data is acceptable.
+
+    Attributes:
+        source_name:    Canonical name of the source (e.g. "wikipedia", "wikidata").
+        source_id:      Identifier used to query the source (page title, QID, ...).
+        success:        True when usable data was extracted; False on complete failure.
+        player_name:    Primary display name.
+        aliases:        Alternative known names (lowercase, deduplicated).
+        birth_year:     Year of birth, if found.
+        birth_place:    Place of birth as raw source string, if available.
+        nationality:    Nationality string *as the source reported it* (no normalisation).
+        nationality_raw: Raw nationality adjective/code for downstream mapping.
+        position:       Playing position *as the source reported it*.
+        career:         Ordered list of career stops.
+        source_metadata: Adapter-specific metadata (retrieved_at, url, revision, ...).
+        raw_payload:    Full source-specific data preserved for provenance (#27).
+        errors:         Non-fatal errors encountered during fetch/parse.
+    """
+
+    source_name: str
+    source_id: str
+    success: bool = False
+
+    player_name: Optional[str] = None
+    aliases: list[str] = field(default_factory=list)
+    birth_year: Optional[int] = None
+    birth_place: Optional[str] = None
+    nationality: Optional[str] = None
+    nationality_raw: Optional[str] = None
+    position: Optional[str] = None
+    career: list[CareerEntry] = field(default_factory=list)
+
+    source_metadata: dict[str, Any] = field(default_factory=dict)
+    raw_payload: dict[str, Any] = field(default_factory=dict)
+    errors: list[AdapterError] = field(default_factory=list)
+
+    def to_dict(self) -> dict[str, Any]:
+        return {
+            "source_name": self.source_name,
+            "source_id": self.source_id,
+            "success": self.success,
+            "player_name": self.player_name,
+            "aliases": list(self.aliases),
+            "birth_year": self.birth_year,
+            "birth_place": self.birth_place,
+            "nationality": self.nationality,
+            "nationality_raw": self.nationality_raw,
+            "position": self.position,
+            "career": [dict(c) for c in self.career],
+            "source_metadata": copy.deepcopy(self.source_metadata),
+            "raw_payload": copy.deepcopy(self.raw_payload),
+            "errors": [e.to_dict() for e in self.errors],
+        }
+
+
+class PlayerSourceAdapter(abc.ABC):
+    """Abstract contract that every player data source must implement.
+
+    Concrete adapters are responsible for:
+    1. Fetching data from their source (Wikipedia, Wikidata, ...);
+    2. Parsing it into a source-neutral ``AdapterResult``;
+    3. Wrapping ALL errors (network, parse, not-found) into ``AdapterError``
+       instances rather than raising unstructured exceptions.
+    """
+
+    @property
+    @abc.abstractmethod
+    def source_name(self) -> str:
+        """Canonical name used as the adapter's source identifier."""
+        ...
+
+    @abc.abstractmethod
+    def fetch_player(self, identifier: str) -> AdapterResult:
+        """Fetch and parse player data for the given source-specific identifier.
+
+        Must NOT raise on recoverable errors — wrap them in ``AdapterResult.errors``
+        and set ``success=False``.
+
+        Args:
+            identifier: Source-specific ID (e.g. Wikipedia page title, Wikidata QID).
+
+        Returns:
+            An ``AdapterResult`` with ``success=True`` on extractable data, or
+            ``success=False`` with structured errors.
+        """
+        ...
+
+    @abc.abstractmethod
+    def search_player(self, query: str, limit: int = 5) -> list[str]:
+        """Search for player identifiers matching a free-text query.
+
+        Returns up to ``limit`` source-specific identifiers.  On error returns
+        an empty list rather than raising (search is best-effort).
+
+        Args:
+            query: Free-text search query (player name, nickname, ...).
+            limit: Maximum number of identifiers to return.
+
+        Returns:
+            List of source-specific identifiers found.
+        """
+        ...
+
+    @staticmethod
+    def _now_iso() -> str:
+        """UTC timestamp in ISO-8601 format."""
+        return datetime.now(timezone.utc).strftime("%Y-%m-%dT%H:%M:%SZ")

--- a/services/adapters/candidate_integration.py
+++ b/services/adapters/candidate_integration.py
@@ -1,0 +1,145 @@
+"""Glue layer between source adapters and Candidate Player Core.
+
+Provides functions to:
+1. Populate a CandidatePlayer from a successful AdapterResult;
+2. Record structured adapter failures into the candidate error log;
+3. Transition the candidate appropriately (DISCOVERED → FETCHED, or
+   DISCOVERED → REVIEW_REQUIRED on partial/ambiguous data).
+
+Does NOT perform normalization, validation, or production promotion.
+Those responsibilities belong to #26 and #15.
+"""
+from __future__ import annotations
+
+from services.adapters.base import AdapterError, AdapterResult
+from services.candidate_player import (
+    CandidatePlayer,
+    CandidateState,
+)
+
+
+def populate_candidate_from_result(
+    candidate: CandidatePlayer,
+    result: AdapterResult,
+) -> CandidatePlayer:
+    """Map adapter result fields onto a CandidatePlayer and transition state.
+
+    If the result is successful and contains usable data, transitions to
+    ``FETCHED``.  If the result is partial (success but with errors, or
+    missing critical fields), transitions to ``REVIEW_REQUIRED``.
+
+    On a failed result, records errors and does NOT transition — callers
+    should use ``record_adapter_failure`` instead.
+
+    Args:
+        candidate: A CandidatePlayer in ``DISCOVERED`` state.
+        result: The AdapterResult from a source adapter.
+
+    Returns:
+        The same candidate instance, mutated in place.
+    """
+    if not result.success:
+        # Record all errors from the failed result
+        for err in result.errors:
+            candidate.record_error(
+                error_type=err.error_type.value,
+                message=err.message,
+                details=err.details,
+                retryable=err.retryable,
+            )
+        return candidate
+
+    # Populate data fields from the result
+    if result.player_name:
+        candidate.full_name = result.player_name
+    if result.aliases:
+        candidate.aliases = list(result.aliases)
+    if result.birth_year is not None:
+        candidate.birth_year = result.birth_year
+    if result.nationality:
+        candidate.nationality = result.nationality
+    if result.position:
+        candidate.position = result.position
+    if result.career:
+        candidate.career = [dict(c) for c in result.career]
+
+    # Store raw source data and metadata for provenance (#27)
+    candidate.raw_data = {
+        "source_name": result.source_name,
+        "source_id": result.source_id,
+        "source_metadata": dict(result.source_metadata),
+        "raw_payload": dict(result.raw_payload),
+    }
+
+    # Record non-fatal errors from the result
+    for err in result.errors:
+        candidate.record_error(
+            error_type=err.error_type.value,
+            message=err.message,
+            details=err.details,
+            retryable=err.retryable,
+            increment_retry_count=False,
+        )
+
+    # Determine target state
+    is_partial = _is_partial_result(result)
+
+    if is_partial and candidate.can_transition_to(CandidateState.REVIEW_REQUIRED):
+        candidate.transition_to(
+            CandidateState.REVIEW_REQUIRED,
+            reason=f"Dati parziali da {result.source_name}: campi mancanti",
+            actor=f"adapter:{result.source_name}",
+        )
+    elif candidate.can_transition_to(CandidateState.FETCHED):
+        candidate.transition_to(
+            CandidateState.FETCHED,
+            reason=f"Dati recuperati da {result.source_name}",
+            actor=f"adapter:{result.source_name}",
+        )
+
+    return candidate
+
+
+def record_adapter_failure(
+    candidate: CandidatePlayer,
+    error: AdapterError,
+) -> CandidatePlayer:
+    """Record a structured adapter failure in the candidate error log.
+
+    Increments the retry count if the error is retryable.  Does NOT
+    transition state — the orchestration layer decides whether to retry,
+    try another source, or move to REVIEW_REQUIRED.
+
+    Args:
+        candidate: The CandidatePlayer to record the error on.
+        error: The structured AdapterError from the adapter.
+
+    Returns:
+        The same candidate instance, mutated in place.
+    """
+    candidate.record_error(
+        error_type=error.error_type.value,
+        message=error.message,
+        details={
+            "source_name": error.source_name,
+            **error.details,
+        },
+        retryable=error.retryable,
+    )
+    return candidate
+
+
+def _is_partial_result(result: AdapterResult) -> bool:
+    """Determine if an AdapterResult has significant missing data.
+
+    A result is considered partial if it's missing the player name OR
+    has fewer than 2 career stops (the dataset minimum) OR has non-fatal
+    errors recorded.
+    """
+    if not result.player_name:
+        return True
+    if len(result.career) < 2:
+        return True
+    if result.errors:
+        return True
+    return False

--- a/services/adapters/candidate_integration.py
+++ b/services/adapters/candidate_integration.py
@@ -3,10 +3,9 @@
 Provides functions to:
 1. Populate a CandidatePlayer from a successful AdapterResult;
 2. Record structured adapter failures into the candidate error log;
-3. Transition the candidate appropriately (DISCOVERED → FETCHED, or
-   DISCOVERED → REVIEW_REQUIRED on partial/ambiguous data).
+3. Transition the candidate from DISCOVERED to FETCHED on successful acquisition.
 
-Does NOT perform normalization, validation, or production promotion.
+Does NOT perform normalization, validation, review assignment, or production promotion.
 Those responsibilities belong to #26 and #15.
 """
 from __future__ import annotations
@@ -81,16 +80,10 @@ def populate_candidate_from_result(
             increment_retry_count=False,
         )
 
-    # Determine target state
-    is_partial = _is_partial_result(result)
-
-    if is_partial and candidate.can_transition_to(CandidateState.REVIEW_REQUIRED):
-        candidate.transition_to(
-            CandidateState.REVIEW_REQUIRED,
-            reason=f"Dati parziali da {result.source_name}: campi mancanti",
-            actor=f"adapter:{result.source_name}",
-        )
-    elif candidate.can_transition_to(CandidateState.FETCHED):
+    # A successful source fetch transitions DISCOVERED → FETCHED.
+    # Downstream normalization and career validation (#26) decide whether
+    # the candidate later becomes NORMALIZED, VALIDATED, or REVIEW_REQUIRED.
+    if candidate.can_transition_to(CandidateState.FETCHED):
         candidate.transition_to(
             CandidateState.FETCHED,
             reason=f"Dati recuperati da {result.source_name}",
@@ -127,19 +120,3 @@ def record_adapter_failure(
         retryable=error.retryable,
     )
     return candidate
-
-
-def _is_partial_result(result: AdapterResult) -> bool:
-    """Determine if an AdapterResult has significant missing data.
-
-    A result is considered partial if it's missing the player name OR
-    has fewer than 2 career stops (the dataset minimum) OR has non-fatal
-    errors recorded.
-    """
-    if not result.player_name:
-        return True
-    if len(result.career) < 2:
-        return True
-    if result.errors:
-        return True
-    return False

--- a/services/adapters/http_client.py
+++ b/services/adapters/http_client.py
@@ -1,0 +1,141 @@
+"""Injectable HTTP client for adapter network calls.
+
+Provides a thin protocol-based abstraction over ``urllib.request`` so that
+unit tests can swap in a fake client without monkey-patching stdlib.
+
+Design:
+- Uses ``urllib.request`` (already used throughout the repo) — no new dependency.
+- Structured error hierarchy: ``HttpError`` wraps HTTP status codes and
+  exposes a ``retryable`` hint for upstream retry decisions.
+- Sensible defaults: 30-second timeout, identifiable User-Agent.
+"""
+from __future__ import annotations
+
+import json
+import urllib.error
+import urllib.parse
+import urllib.request
+from dataclasses import dataclass, field
+from typing import Any, Optional, Protocol, runtime_checkable
+
+
+@dataclass
+class HttpResponse:
+    """Structured HTTP response."""
+
+    status_code: int
+    body: str
+    headers: dict[str, str] = field(default_factory=dict)
+
+    def json(self) -> Any:
+        """Parse body as JSON; raises ``ValueError`` on invalid JSON."""
+        return json.loads(self.body)
+
+
+class HttpError(Exception):
+    """Structured HTTP error with status code and retry hint."""
+
+    def __init__(
+        self,
+        status_code: int,
+        message: str,
+        *,
+        url: str = "",
+        retryable: bool = False,
+        body: str = "",
+    ) -> None:
+        self.status_code = status_code
+        self.message = message
+        self.url = url
+        self.retryable = retryable
+        self.body = body
+        super().__init__(f"HTTP {status_code}: {message} [{url}]")
+
+
+@runtime_checkable
+class HttpClient(Protocol):
+    """Protocol for injectable HTTP clients."""
+
+    def get(self, url: str, *, timeout: int = 30) -> HttpResponse:
+        """Perform a GET request and return the response.
+
+        Raises:
+            HttpError: On non-2xx responses.
+            TimeoutError: On request timeout.
+        """
+        ...
+
+
+_DEFAULT_UA = "guess-the-player-dataset/1.0 (adapter pipeline; contact: repo owner)"
+_DEFAULT_TIMEOUT = 30
+
+
+class UrllibHttpClient:
+    """Default HTTP client implementation using ``urllib.request``.
+
+    Supports configurable timeout and User-Agent.  Does NOT perform retries
+    internally — retry decisions belong to the orchestration layer.
+    """
+
+    def __init__(
+        self,
+        *,
+        user_agent: str = _DEFAULT_UA,
+        default_timeout: int = _DEFAULT_TIMEOUT,
+    ) -> None:
+        self._user_agent = user_agent
+        self._default_timeout = default_timeout
+
+    def get(self, url: str, *, timeout: Optional[int] = None) -> HttpResponse:
+        """Perform a GET request.
+
+        Raises:
+            HttpError: On HTTP error status codes.
+            TimeoutError: On timeout.
+        """
+        effective_timeout = timeout if timeout is not None else self._default_timeout
+        req = urllib.request.Request(url, headers={"User-Agent": self._user_agent})
+
+        try:
+            resp = urllib.request.urlopen(req, timeout=effective_timeout)
+            body = resp.read().decode("utf-8")
+            headers = {k: v for k, v in resp.getheaders()}
+            return HttpResponse(
+                status_code=resp.status,
+                body=body,
+                headers=headers,
+            )
+        except urllib.error.HTTPError as exc:
+            status = exc.code
+            err_body = ""
+            try:
+                err_body = exc.read().decode("utf-8", errors="replace")
+            except Exception:
+                pass
+
+            retryable = status in (429, 500, 502, 503, 504)
+            raise HttpError(
+                status_code=status,
+                message=exc.reason or f"HTTP {status}",
+                url=url,
+                retryable=retryable,
+                body=err_body,
+            ) from exc
+        except urllib.error.URLError as exc:
+            if "timed out" in str(exc).lower() or isinstance(exc.reason, TimeoutError):
+                raise TimeoutError(f"Request timed out: {url}") from exc
+            raise HttpError(
+                status_code=0,
+                message=str(exc.reason),
+                url=url,
+                retryable=True,
+            ) from exc
+        except TimeoutError:
+            raise
+        except OSError as exc:
+            raise HttpError(
+                status_code=0,
+                message=str(exc),
+                url=url,
+                retryable=True,
+            ) from exc

--- a/services/adapters/wikidata.py
+++ b/services/adapters/wikidata.py
@@ -1,0 +1,326 @@
+"""Wikidata adapter for structured player data acquisition.
+
+Fetches footballer data from the Wikidata entity API — a structured,
+machine-readable source complementary to Wikipedia's free-text infoboxes.
+
+Wikidata properties used:
+- P31  (instance of) — to verify the entity is a human
+- P106 (occupation) — to verify the entity is a footballer
+- P27  (country of citizenship) — nationality
+- P413 (position played on team) — playing position
+- P569 (date of birth) — birth year
+- P54  (member of sports team) — career history
+  - P580 (start time) qualifier — start year
+  - P582 (end time) qualifier — end year
+  - P118 (league) qualifier — league
+  - P1642 (number of matches played) qualifier — appearances
+  - P1351 (number of goals) qualifier — goals
+"""
+from __future__ import annotations
+
+import re
+import urllib.parse
+from typing import Any, Optional
+
+from services.adapters.base import (
+    AdapterError,
+    AdapterErrorType,
+    AdapterResult,
+    CareerEntry,
+    PlayerSourceAdapter,
+)
+from services.adapters.http_client import HttpClient, HttpError, UrllibHttpClient
+
+_SOURCE_NAME = "wikidata"
+_ENTITY_API = "https://www.wikidata.org/wiki/Special:EntityData/{qid}.json"
+
+# ── Position mapping (Wikidata QIDs → dataset labels) ────────────────────
+
+_POSITION_MAP: dict[str, str] = {
+    "Q193592": "Attaccante",        # forward
+    "Q280658": "Centrocampista",    # midfielder
+    "Q336286": "Difensore",         # defender
+    "Q201330": "Portiere",          # goalkeeper
+    "Q4611891": "Centrocampista",   # winger (maps to centrocampista in dataset)
+    "Q2383640": "Centrocampista",   # attacking midfielder
+    "Q1249716": "Centrocampista",   # defensive midfielder
+    "Q6543924": "Attaccante",       # centre-forward
+    "Q1397417": "Difensore",        # centre-back
+    "Q1203494": "Difensore",        # full-back
+    "Q18553490": "Difensore",       # wing-back
+}
+
+
+class WikidataAdapter(PlayerSourceAdapter):
+    """Adapter for Wikidata entity JSON API.
+
+    Uses the Wikidata REST entity endpoint (no SPARQL) for simplicity
+    and testability.  Extracts player data from claims/qualifiers.
+    """
+
+    def __init__(self, http_client: Optional[HttpClient] = None) -> None:
+        self._http = http_client or UrllibHttpClient()
+
+    @property
+    def source_name(self) -> str:
+        return _SOURCE_NAME
+
+    # ── Public contract ──────────────────────────────────────────────────
+
+    def fetch_player(self, identifier: str) -> AdapterResult:
+        """Fetch and parse a Wikidata entity.
+
+        ``identifier`` is a Wikidata QID (e.g. ``"Q1853"`` for Totti).
+        """
+        qid = self._normalize_qid(identifier)
+        result = AdapterResult(source_name=_SOURCE_NAME, source_id=qid)
+
+        # 1. Fetch entity JSON
+        entity: Optional[dict[str, Any]] = None
+        try:
+            entity = self._fetch_entity(qid)
+        except Exception as exc:
+            result.errors.append(self._error_from_exception(exc, qid))
+            return result
+
+        if entity is None:
+            result.errors.append(AdapterError(
+                error_type=AdapterErrorType.NOT_FOUND,
+                message=f"Entità non trovata: {qid}",
+                source_name=_SOURCE_NAME,
+                retryable=False,
+            ))
+            return result
+
+        result.raw_payload = {"entity": entity, "qid": qid}
+        result.source_metadata["retrieved_at"] = self._now_iso()
+        result.source_metadata["url"] = f"https://www.wikidata.org/wiki/{qid}"
+
+        # 2. Extract data
+        try:
+            self._extract_player_data(entity, result)
+        except Exception as exc:
+            result.errors.append(AdapterError(
+                error_type=AdapterErrorType.PARSE,
+                message=f"Errore nel parsing dell'entità: {exc}",
+                source_name=_SOURCE_NAME,
+                details={"qid": qid},
+                retryable=False,
+            ))
+
+        result.success = bool(result.player_name or result.career)
+        return result
+
+    def search_player(self, query: str, limit: int = 5) -> list[str]:
+        """Search Wikidata for entity QIDs matching a query."""
+        url = (
+            "https://www.wikidata.org/w/api.php"
+            "?action=wbsearchentities"
+            "&search=" + urllib.parse.quote(query)
+            + f"&language=it&limit={limit}&format=json"
+        )
+        try:
+            resp = self._http.get(url)
+            data = resp.json()
+            return [hit["id"] for hit in data.get("search", [])]
+        except Exception:
+            return []
+
+    # ── HTTP layer ───────────────────────────────────────────────────────
+
+    def _fetch_entity(self, qid: str) -> Optional[dict[str, Any]]:
+        """Fetch the raw Wikidata entity JSON."""
+        url = _ENTITY_API.format(qid=qid)
+        resp = self._http.get(url)
+        data = resp.json()
+        entities = data.get("entities", {})
+        return entities.get(qid)
+
+    # ── Data extraction ──────────────────────────────────────────────────
+
+    def _extract_player_data(self, entity: dict[str, Any], result: AdapterResult) -> None:
+        """Populate the AdapterResult from a Wikidata entity dict."""
+        claims = entity.get("claims", {})
+
+        # Name: prefer Italian label, fallback to English, then any
+        labels = entity.get("labels", {})
+        result.player_name = self._best_label(labels)
+
+        # Aliases
+        aliases_data = entity.get("aliases", {})
+        seen: set[str] = set()
+        for lang in ("it", "en", "es", "fr", "de", "pt"):
+            for entry in aliases_data.get(lang, []):
+                val = entry.get("value", "").strip().lower()
+                if val and val not in seen:
+                    result.aliases.append(val)
+                    seen.add(val)
+
+        # Birth year (P569)
+        result.birth_year = self._extract_year_from_claims(claims, "P569")
+
+        # Nationality (P27)
+        result.nationality = self._extract_entity_label(claims, "P27")
+
+        # Position (P413)
+        result.position = self._extract_position(claims)
+
+        # Career (P54 — member of sports team)
+        result.career = self._extract_career(claims)
+
+    @staticmethod
+    def _best_label(labels: dict[str, Any]) -> Optional[str]:
+        """Pick the best label from Wikidata labels dict."""
+        for lang in ("it", "en", "es", "fr", "de", "pt"):
+            if lang in labels:
+                return labels[lang].get("value")
+        if labels:
+            return next(iter(labels.values())).get("value")
+        return None
+
+    @staticmethod
+    def _extract_year_from_claims(claims: dict[str, Any], prop: str) -> Optional[int]:
+        """Extract a year from a time-valued claim."""
+        for claim in claims.get(prop, []):
+            mainsnak = claim.get("mainsnak", {})
+            dv = mainsnak.get("datavalue", {})
+            if dv.get("type") == "time":
+                time_str = dv.get("value", {}).get("time", "")
+                m = re.search(r"(\d{4})", time_str)
+                if m:
+                    return int(m.group(1))
+        return None
+
+    @staticmethod
+    def _extract_entity_label(claims: dict[str, Any], prop: str) -> Optional[str]:
+        """Extract the label of the first entity-valued claim (e.g. nationality)."""
+        for claim in claims.get(prop, []):
+            mainsnak = claim.get("mainsnak", {})
+            dv = mainsnak.get("datavalue", {})
+            if dv.get("type") == "wikibase-entityid":
+                qid = dv.get("value", {}).get("id")
+                if qid:
+                    return qid  # Return QID; downstream maps to country name
+        return None
+
+    @classmethod
+    def _extract_position(cls, claims: dict[str, Any]) -> Optional[str]:
+        """Map P413 (position played on team) to dataset position labels."""
+        for claim in claims.get("P413", []):
+            mainsnak = claim.get("mainsnak", {})
+            dv = mainsnak.get("datavalue", {})
+            if dv.get("type") == "wikibase-entityid":
+                qid = dv.get("value", {}).get("id")
+                if qid and qid in _POSITION_MAP:
+                    return _POSITION_MAP[qid]
+        return None
+
+    @classmethod
+    def _extract_career(cls, claims: dict[str, Any]) -> list[CareerEntry]:
+        """Extract career stops from P54 (member of sports team) with qualifiers."""
+        stops: list[CareerEntry] = []
+        for claim in claims.get("P54", []):
+            mainsnak = claim.get("mainsnak", {})
+            dv = mainsnak.get("datavalue", {})
+            if dv.get("type") != "wikibase-entityid":
+                continue
+
+            team_qid = dv.get("value", {}).get("id")
+            if not team_qid:
+                continue
+
+            qualifiers = claim.get("qualifiers", {})
+
+            entry: CareerEntry = {
+                "team": team_qid,  # QID — downstream resolves to name
+                "start_year": cls._year_from_qualifier(qualifiers, "P580"),
+                "end_year": cls._year_from_qualifier(qualifiers, "P582"),
+                "apps": cls._int_from_qualifier(qualifiers, "P1642"),
+                "goals": cls._int_from_qualifier(qualifiers, "P1351"),
+            }
+
+            # Sport number (P1618) = jersey number — not needed but harmless
+
+            stops.append(entry)
+
+        return stops
+
+    @staticmethod
+    def _year_from_qualifier(qualifiers: dict[str, Any], prop: str) -> Optional[int]:
+        """Extract a year from a qualifier time value."""
+        for q in qualifiers.get(prop, []):
+            dv = q.get("datavalue", {})
+            if dv.get("type") == "time":
+                time_str = dv.get("value", {}).get("time", "")
+                m = re.search(r"(\d{4})", time_str)
+                if m:
+                    return int(m.group(1))
+        return None
+
+    @staticmethod
+    def _int_from_qualifier(qualifiers: dict[str, Any], prop: str) -> Optional[int]:
+        """Extract an integer from a quantity qualifier."""
+        for q in qualifiers.get(prop, []):
+            dv = q.get("datavalue", {})
+            if dv.get("type") == "quantity":
+                try:
+                    return int(float(dv.get("value", {}).get("amount", "")))
+                except (ValueError, TypeError):
+                    pass
+        return None
+
+    @staticmethod
+    def _normalize_qid(identifier: str) -> str:
+        """Ensure identifier is a clean QID (e.g. 'Q1853')."""
+        identifier = identifier.strip()
+        if re.match(r"^Q\d+$", identifier, re.I):
+            return identifier.upper()
+        # Try to extract from a URL
+        m = re.search(r"(Q\d+)", identifier, re.I)
+        if m:
+            return m.group(1).upper()
+        return identifier
+
+    # ── Error helpers ────────────────────────────────────────────────────
+
+    def _error_from_exception(self, exc: Exception, identifier: str) -> AdapterError:
+        """Convert an exception into a structured ``AdapterError``."""
+        if isinstance(exc, HttpError):
+            if exc.status_code == 404:
+                return AdapterError(
+                    error_type=AdapterErrorType.NOT_FOUND,
+                    message=f"Entità non trovata: {identifier}",
+                    source_name=_SOURCE_NAME,
+                    details={"status_code": exc.status_code, "url": exc.url},
+                    retryable=False,
+                )
+            if exc.status_code == 429:
+                return AdapterError(
+                    error_type=AdapterErrorType.RATE_LIMIT,
+                    message=f"Rate limited: {identifier}",
+                    source_name=_SOURCE_NAME,
+                    details={"status_code": exc.status_code},
+                    retryable=True,
+                )
+            return AdapterError(
+                error_type=AdapterErrorType.TRANSPORT,
+                message=f"HTTP {exc.status_code}: {exc.message}",
+                source_name=_SOURCE_NAME,
+                details={"status_code": exc.status_code, "url": exc.url},
+                retryable=exc.retryable,
+            )
+        if isinstance(exc, TimeoutError):
+            return AdapterError(
+                error_type=AdapterErrorType.TIMEOUT,
+                message=f"Timeout: {exc}",
+                source_name=_SOURCE_NAME,
+                details={"identifier": identifier},
+                retryable=True,
+            )
+        return AdapterError(
+            error_type=AdapterErrorType.UNKNOWN,
+            message=f"{type(exc).__name__}: {exc}",
+            source_name=_SOURCE_NAME,
+            details={"identifier": identifier},
+            retryable=False,
+        )

--- a/services/adapters/wikidata.py
+++ b/services/adapters/wikidata.py
@@ -13,11 +13,12 @@ Wikidata properties used:
   - P580 (start time) qualifier — start year
   - P582 (end time) qualifier — end year
   - P118 (league) qualifier — league
-  - P1642 (number of matches played) qualifier — appearances
-  - P1351 (number of goals) qualifier — goals
+  - P1350 (number of matches played/races/starts) qualifier — appearances
+  - P1351 (number of goals/points scored) qualifier — goals
 """
 from __future__ import annotations
 
+import json
 import re
 import urllib.parse
 from typing import Any, Optional
@@ -26,6 +27,7 @@ from services.adapters.base import (
     AdapterError,
     AdapterErrorType,
     AdapterResult,
+    AdapterSearchResult,
     CareerEntry,
     PlayerSourceAdapter,
 )
@@ -80,7 +82,7 @@ class WikidataAdapter(PlayerSourceAdapter):
         try:
             entity = self._fetch_entity(qid)
         except Exception as exc:
-            result.errors.append(self._error_from_exception(exc, qid))
+            result.errors.append(self._error_from_exception(exc, qid, phase="fetch"))
             return result
 
         if entity is None:
@@ -88,6 +90,7 @@ class WikidataAdapter(PlayerSourceAdapter):
                 error_type=AdapterErrorType.NOT_FOUND,
                 message=f"Entità non trovata: {qid}",
                 source_name=_SOURCE_NAME,
+                details={"phase": "fetch", "identifier": qid},
                 retryable=False,
             ))
             return result
@@ -104,15 +107,16 @@ class WikidataAdapter(PlayerSourceAdapter):
                 error_type=AdapterErrorType.PARSE,
                 message=f"Errore nel parsing dell'entità: {exc}",
                 source_name=_SOURCE_NAME,
-                details={"qid": qid},
+                details={"phase": "extraction", "qid": qid, "exception": str(exc)},
                 retryable=False,
             ))
 
         result.success = bool(result.player_name or result.career)
         return result
 
-    def search_player(self, query: str, limit: int = 5) -> list[str]:
+    def search_player(self, query: str, limit: int = 5) -> AdapterSearchResult:
         """Search Wikidata for entity QIDs matching a query."""
+        result = AdapterSearchResult(source_name=_SOURCE_NAME, query=query)
         url = (
             "https://www.wikidata.org/w/api.php"
             "?action=wbsearchentities"
@@ -122,9 +126,20 @@ class WikidataAdapter(PlayerSourceAdapter):
         try:
             resp = self._http.get(url)
             data = resp.json()
-            return [hit["id"] for hit in data.get("search", [])]
-        except Exception:
-            return []
+            if not isinstance(data, dict):
+                raise ValueError("Risposta API Wikidata non valida: atteso dizionario JSON")
+            search_items = data.get("search", [])
+            if not isinstance(search_items, list):
+                raise ValueError("Risposta API Wikidata non valida: 'search' non è una lista")
+            result.identifiers = [
+                hit["id"] for hit in search_items if isinstance(hit, dict) and "id" in hit
+            ]
+            result.success = True
+            return result
+        except Exception as exc:
+            result.success = False
+            result.errors.append(self._error_from_exception(exc, query, phase="search"))
+            return result
 
     # ── HTTP layer ───────────────────────────────────────────────────────
 
@@ -133,8 +148,15 @@ class WikidataAdapter(PlayerSourceAdapter):
         url = _ENTITY_API.format(qid=qid)
         resp = self._http.get(url)
         data = resp.json()
-        entities = data.get("entities", {})
-        return entities.get(qid)
+        if not isinstance(data, dict):
+            raise ValueError("Risposta Wikidata non valida: atteso oggetto JSON")
+        entities = data.get("entities")
+        if not isinstance(entities, dict):
+            raise ValueError("Risposta Wikidata non valida: blocco 'entities' mancante o non valido")
+        entity = entities.get(qid)
+        if entity is None or not isinstance(entity, dict):
+            return None
+        return entity
 
     # ── Data extraction ──────────────────────────────────────────────────
 
@@ -235,7 +257,7 @@ class WikidataAdapter(PlayerSourceAdapter):
                 "team": team_qid,  # QID — downstream resolves to name
                 "start_year": cls._year_from_qualifier(qualifiers, "P580"),
                 "end_year": cls._year_from_qualifier(qualifiers, "P582"),
-                "apps": cls._int_from_qualifier(qualifiers, "P1642"),
+                "apps": cls._int_from_qualifier(qualifiers, "P1350"),
                 "goals": cls._int_from_qualifier(qualifiers, "P1351"),
             }
 
@@ -283,15 +305,30 @@ class WikidataAdapter(PlayerSourceAdapter):
 
     # ── Error helpers ────────────────────────────────────────────────────
 
-    def _error_from_exception(self, exc: Exception, identifier: str) -> AdapterError:
+    @classmethod
+    def _error_from_exception(
+        cls,
+        exc: Exception,
+        identifier: str,
+        *,
+        phase: str = "response_parsing",
+    ) -> AdapterError:
         """Convert an exception into a structured ``AdapterError``."""
+        if isinstance(exc, (json.JSONDecodeError, ValueError, TypeError)):
+            return AdapterError(
+                error_type=AdapterErrorType.PARSE,
+                message=f"Risposta non valida o malformata per {identifier}: {exc}",
+                source_name=_SOURCE_NAME,
+                details={"phase": phase, "identifier": identifier, "exception": str(exc)},
+                retryable=False,
+            )
         if isinstance(exc, HttpError):
             if exc.status_code == 404:
                 return AdapterError(
                     error_type=AdapterErrorType.NOT_FOUND,
                     message=f"Entità non trovata: {identifier}",
                     source_name=_SOURCE_NAME,
-                    details={"status_code": exc.status_code, "url": exc.url},
+                    details={"status_code": exc.status_code, "url": exc.url, "phase": phase},
                     retryable=False,
                 )
             if exc.status_code == 429:
@@ -299,14 +336,14 @@ class WikidataAdapter(PlayerSourceAdapter):
                     error_type=AdapterErrorType.RATE_LIMIT,
                     message=f"Rate limited: {identifier}",
                     source_name=_SOURCE_NAME,
-                    details={"status_code": exc.status_code},
+                    details={"status_code": exc.status_code, "phase": phase},
                     retryable=True,
                 )
             return AdapterError(
                 error_type=AdapterErrorType.TRANSPORT,
                 message=f"HTTP {exc.status_code}: {exc.message}",
                 source_name=_SOURCE_NAME,
-                details={"status_code": exc.status_code, "url": exc.url},
+                details={"status_code": exc.status_code, "url": exc.url, "phase": phase},
                 retryable=exc.retryable,
             )
         if isinstance(exc, TimeoutError):
@@ -314,13 +351,13 @@ class WikidataAdapter(PlayerSourceAdapter):
                 error_type=AdapterErrorType.TIMEOUT,
                 message=f"Timeout: {exc}",
                 source_name=_SOURCE_NAME,
-                details={"identifier": identifier},
+                details={"identifier": identifier, "phase": phase},
                 retryable=True,
             )
         return AdapterError(
             error_type=AdapterErrorType.UNKNOWN,
             message=f"{type(exc).__name__}: {exc}",
             source_name=_SOURCE_NAME,
-            details={"identifier": identifier},
+            details={"identifier": identifier, "phase": phase},
             retryable=False,
         )

--- a/services/adapters/wikipedia.py
+++ b/services/adapters/wikipedia.py
@@ -1,0 +1,405 @@
+"""Wikipedia adapter for player data acquisition.
+
+Encapsulates Wikipedia (it.wikipedia.org) player fetch/parse behind the
+``PlayerSourceAdapter`` contract.  Reuses the proven parsing logic from
+``scripts/wikipedia/wiki.py`` where possible, wrapping all behaviour in
+structured ``AdapterResult`` / ``AdapterError`` types.
+
+The existing ``wiki.py`` module is NOT modified — this adapter delegates to
+its parsing functions and wraps the HTTP layer via the injectable
+``HttpClient`` for testability.
+"""
+from __future__ import annotations
+
+import re
+import urllib.parse
+from typing import Any, Optional
+
+from services.adapters.base import (
+    AdapterError,
+    AdapterErrorType,
+    AdapterResult,
+    CareerEntry,
+    PlayerSourceAdapter,
+)
+from services.adapters.http_client import HttpClient, HttpError, UrllibHttpClient
+
+# ── Wikipedia API constants ──────────────────────────────────────────────
+
+_API = "https://it.wikipedia.org/w/api.php"
+_SOURCE_NAME = "wikipedia"
+
+
+class WikipediaAdapter(PlayerSourceAdapter):
+    """Adapter for ``it.wikipedia.org`` player data.
+
+    Fetches the wikitext of a page via the MediaWiki API and parses the
+    ``{{Sportivo}}`` / ``{{Calciatore}}`` infobox plus ``{{Bio}}`` template
+    to extract career stops, profile data and metadata.
+
+    Parsing functions are local re-implementations of the algorithms in
+    ``scripts/wikipedia/wiki.py``, adapted to use the injectable ``HttpClient``
+    and to wrap all errors into structured ``AdapterError`` instances instead
+    of raising bare exceptions.
+    """
+
+    def __init__(self, http_client: Optional[HttpClient] = None) -> None:
+        self._http = http_client or UrllibHttpClient()
+
+    @property
+    def source_name(self) -> str:
+        return _SOURCE_NAME
+
+    # ── Public contract ──────────────────────────────────────────────────
+
+    def fetch_player(self, identifier: str) -> AdapterResult:
+        """Fetch and parse a player page from it.wikipedia.org.
+
+        ``identifier`` is the page title (e.g. ``"Francesco Totti"``).
+        """
+        result = AdapterResult(source_name=_SOURCE_NAME, source_id=identifier)
+
+        # 1. Fetch wikitext
+        wikitext: Optional[str] = None
+        try:
+            wikitext = self._fetch_wikitext(identifier)
+        except Exception as exc:
+            result.errors.append(self._error_from_exception(exc, identifier))
+            return result
+
+        if wikitext is None:
+            result.errors.append(AdapterError(
+                error_type=AdapterErrorType.NOT_FOUND,
+                message=f"Pagina non trovata: {identifier}",
+                source_name=_SOURCE_NAME,
+                retryable=False,
+            ))
+            return result
+
+        result.raw_payload = {"wikitext": wikitext, "title": identifier}
+        result.source_metadata["retrieved_at"] = self._now_iso()
+        result.source_metadata["url"] = (
+            f"https://it.wikipedia.org/wiki/{urllib.parse.quote(identifier.replace(' ', '_'))}"
+        )
+
+        # 2. Parse profile
+        try:
+            profile = self._parse_profile(wikitext)
+            result.player_name = profile.get("full_name")
+            result.position = profile.get("position")
+            result.nationality = profile.get("country_code")
+            result.nationality_raw = profile.get("nationality_raw")
+            result.birth_year = profile.get("birth_year")
+        except Exception as exc:
+            result.errors.append(AdapterError(
+                error_type=AdapterErrorType.PARSE,
+                message=f"Errore nel parsing del profilo: {exc}",
+                source_name=_SOURCE_NAME,
+                details={"phase": "profile", "title": identifier},
+                retryable=False,
+            ))
+
+        # 3. Parse career
+        try:
+            result.career = self._parse_career(wikitext)
+        except Exception as exc:
+            result.errors.append(AdapterError(
+                error_type=AdapterErrorType.PARSE,
+                message=f"Errore nel parsing della carriera: {exc}",
+                source_name=_SOURCE_NAME,
+                details={"phase": "career", "title": identifier},
+                retryable=False,
+            ))
+
+        # Determine success: at least a name or career data
+        result.success = bool(result.player_name or result.career)
+        return result
+
+    def search_player(self, query: str, limit: int = 5) -> list[str]:
+        """Search for page titles matching a query on it.wikipedia.org."""
+        url = (
+            _API
+            + "?action=query&list=search&srsearch="
+            + urllib.parse.quote(query)
+            + f"&srlimit={limit}&format=json&formatversion=2"
+        )
+        try:
+            resp = self._http.get(url)
+            data = resp.json()
+            return [
+                hit["title"]
+                for hit in data.get("query", {}).get("search", [])
+            ]
+        except Exception:
+            return []
+
+    # ── HTTP layer ───────────────────────────────────────────────────────
+
+    def _fetch_wikitext(self, title: str) -> Optional[str]:
+        """Fetch raw wikitext for a page via the MediaWiki parse API."""
+        url = (
+            _API
+            + "?action=parse&page="
+            + urllib.parse.quote(title)
+            + "&prop=wikitext&format=json&formatversion=2&redirects=1"
+        )
+        resp = self._http.get(url)
+        data = resp.json()
+
+        if "parse" not in data:
+            return None
+        return data["parse"]["wikitext"]
+
+    # ── Wikitext parsing (adapted from scripts/wikipedia/wiki.py) ────────
+
+    @staticmethod
+    def _strip_markup(value: str) -> str:
+        """Remove wiki markup, refs, templates and links leaving readable text."""
+        value = re.sub(r"<ref[^>]*/>", "", value)
+        value = re.sub(r"\[\[\s*(?:File|Immagine|Image):[^\]]*\]\]", "", value, flags=re.I)
+        value = re.sub(r"\b\d+px\s*\|", "", value)
+        value = re.sub(r"<ref.*?</ref>", "", value, flags=re.S)
+        value = re.sub(r"<!--.*?-->", "", value, flags=re.S)
+        value = re.sub(r"\{\{\s*[Bb]andiera\s*\|[^}]*\}\}", "", value)
+        value = re.sub(r"\{\{\s*(?:Calcio|Naz)\s+([^|}]+)(?:\|[^}]*)?\}\}", r"\1", value)
+        value = re.sub(r"\{\{[^}]*\}\}", "", value)
+        value = re.sub(r"\[\[[^|\]]*\|([^\]]*)\]\]", r"\1", value)
+        value = re.sub(r"\[\[([^\]]*)\]\]", r"\1", value)
+        value = re.sub(r"</?[a-zA-Z][^>]*>", "", value)
+        value = value.replace("'''", "").replace("''", "")
+        return value.strip()
+
+    @staticmethod
+    def _split_template_args(body: str) -> list[str]:
+        """Split on top-level '|' (ignoring {{...}} and [[...]])."""
+        parts: list[str] = []
+        depth_c = 0
+        depth_b = 0
+        current = ""
+        i = 0
+        while i < len(body):
+            two = body[i:i + 2]
+            if two in ("{{", "}}", "[[", "]]"):
+                if two == "{{":
+                    depth_c += 1
+                elif two == "}}":
+                    depth_c -= 1
+                elif two == "[[":
+                    depth_b += 1
+                else:
+                    depth_b -= 1
+                current += two
+                i += 2
+                continue
+            ch = body[i]
+            if ch == "|" and depth_c == 0 and depth_b == 0:
+                parts.append(current)
+                current = ""
+            else:
+                current += ch
+            i += 1
+        parts.append(current)
+        return parts
+
+    @staticmethod
+    def _find_template(text: str, name: str) -> Optional[str]:
+        """Extract the body of the first ``{{name ...}}`` template, balancing braces."""
+        match = re.search(r"\{\{\s*" + name + r"\b", text)
+        if not match:
+            return None
+        start = match.start()
+        depth = 0
+        i = start
+        while i < len(text):
+            if text[i:i + 2] == "{{":
+                depth += 1
+                i += 2
+                continue
+            if text[i:i + 2] == "}}":
+                depth -= 1
+                i += 2
+                if depth == 0:
+                    return text[start + 2:i - 2]
+                continue
+            i += 1
+        return None
+
+    @classmethod
+    def _named_params(cls, body: str) -> dict[str, str]:
+        """Extract named parameters from a template body."""
+        out: dict[str, str] = {}
+        for part in cls._split_template_args(body):
+            if "=" in part:
+                key, _, value = part.partition("=")
+                out[key.strip().lower()] = value.strip()
+        return out
+
+    _YEARS = re.compile(
+        r"^\s*(?:[a-z]{3}\.?\s*)?(\d{4})\s*(?:[-–—]\s*(?:[a-z]{3}\.?\s*)?(\d{4})?)?\s*$",
+        re.I,
+    )
+
+    @classmethod
+    def _parse_years(cls, token: str) -> Optional[tuple[int, Optional[int]]]:
+        m = cls._YEARS.match(cls._strip_markup(token))
+        if not m:
+            return None
+        start = int(m.group(1))
+        if m.group(2):
+            return start, int(m.group(2))
+        return (start, None) if "-" in token or "–" in token else (start, start)
+
+    _STATS = re.compile(r"(\d+)\s*(?:\((-?\d+)\))?")
+
+    @classmethod
+    def _parse_stats(cls, token: str) -> tuple[Optional[int], Optional[int]]:
+        token = cls._strip_markup(token)
+        m = cls._STATS.search(token)
+        if not m:
+            return None, None
+        goals = int(m.group(2)) if m.group(2) is not None else None
+        return int(m.group(1)), goals
+
+    # ── Role mapping ─────────────────────────────────────────────────────
+
+    _ROLES: list[tuple[str, str]] = [
+        ("portiere", "Portiere"),
+        ("difensore", "Difensore"), ("terzino", "Difensore"), ("libero", "Difensore"),
+        ("centrocampista", "Centrocampista"), ("mediano", "Centrocampista"),
+        ("regista", "Centrocampista"), ("ala", "Centrocampista"), ("trequartista", "Centrocampista"),
+        ("attaccante", "Attaccante"), ("punta", "Attaccante"), ("centravanti", "Attaccante"),
+    ]
+
+    # ── High-level parsing ───────────────────────────────────────────────
+
+    @classmethod
+    def _parse_career(cls, wt: str) -> list[CareerEntry]:
+        """Extract club career stops from wikitext infobox."""
+        infobox = cls._find_template(wt, "Sportivo") or cls._find_template(wt, "Calciatore")
+        if not infobox:
+            return []
+        params = cls._named_params(infobox)
+        squadre = params.get("squadre")
+        if not squadre:
+            return []
+        body = cls._find_template(squadre, "Carriera sportivo")
+        if not body:
+            return []
+
+        # Strip refs/comments BEFORE splitting (avoids alignment problems)
+        body = re.sub(r"<ref[^>]*/>", "", body)
+        body = re.sub(r"<ref[^>]*>.*?</ref>", "", body, flags=re.S)
+        body = re.sub(r"<!--.*?-->", "", body, flags=re.S)
+
+        args = cls._split_template_args(body)[1:]
+        positional = [a for a in args if not re.match(r"\s*[A-Za-z][\w -]*=", a)]
+        stops: list[CareerEntry] = []
+        for i in range(0, len(positional) - 2, 3):
+            years = cls._parse_years(positional[i])
+            if not years:
+                continue
+            raw_team = positional[i + 1]
+            loan = "→" in raw_team or "&rarr;" in raw_team
+            team = cls._strip_markup(raw_team.replace("→", "").replace("&rarr;", ""))
+            team = re.sub(r"^\W+", "", team).strip()
+            if not team:
+                continue
+            apps, goals = cls._parse_stats(positional[i + 2])
+
+            # Extract wiki link target
+            link: Optional[str] = None
+            m = re.search(r"\[\[\s*([^|\]]+?)\s*(?:\|[^\]]*)?]]", raw_team)
+            if m and not re.match(r"(?i)(file|immagine|image):", m.group(1)):
+                link = m.group(1).strip()
+
+            entry: CareerEntry = {
+                "team": team,
+                "start_year": years[0],
+                "end_year": years[1],
+                "apps": apps,
+                "goals": goals,
+            }
+            if link:
+                entry["link"] = link
+            if loan:
+                entry["loan"] = True
+            stops.append(entry)
+        return stops
+
+    @classmethod
+    def _parse_profile(cls, wt: str) -> dict[str, Any]:
+        """Extract profile data from wikitext infobox + Bio template."""
+        infobox = cls._find_template(wt, "Sportivo") or cls._find_template(wt, "Calciatore") or ""
+        params = cls._named_params(infobox)
+        role_raw = cls._strip_markup(params.get("ruolo", "")).lower()
+        position: Optional[str] = None
+        for needle, label in cls._ROLES:
+            if needle in role_raw:
+                position = label
+                break
+
+        country_code: Optional[str] = None
+        m = re.search(r"\{\{\s*([A-Z]{3})\s*\}\}", params.get("codicenazione", ""))
+        if m:
+            country_code = m.group(1)
+
+        bio = cls._find_template(wt, "Bio") or ""
+        bio_params = cls._named_params(bio)
+        birth = bio_params.get("annonascita", "")
+        m_birth = re.search(r"(\d{4})", birth)
+        birth_year = int(m_birth.group(1)) if m_birth else None
+        name = " ".join(
+            x for x in (bio_params.get("nome", ""), bio_params.get("cognome", "")) if x
+        ).strip()
+
+        return {
+            "position": position,
+            "country_code": country_code,
+            "birth_year": birth_year,
+            "full_name": cls._strip_markup(name) or None,
+            "nationality_raw": cls._strip_markup(bio_params.get("nazionalità", "")),
+        }
+
+    # ── Error helpers ────────────────────────────────────────────────────
+
+    def _error_from_exception(self, exc: Exception, identifier: str) -> AdapterError:
+        """Convert an exception into a structured ``AdapterError``."""
+        if isinstance(exc, HttpError):
+            if exc.status_code == 404:
+                return AdapterError(
+                    error_type=AdapterErrorType.NOT_FOUND,
+                    message=f"Pagina non trovata: {identifier}",
+                    source_name=_SOURCE_NAME,
+                    details={"status_code": exc.status_code, "url": exc.url},
+                    retryable=False,
+                )
+            if exc.status_code == 429:
+                return AdapterError(
+                    error_type=AdapterErrorType.RATE_LIMIT,
+                    message=f"Rate limited: {identifier}",
+                    source_name=_SOURCE_NAME,
+                    details={"status_code": exc.status_code, "url": exc.url},
+                    retryable=True,
+                )
+            return AdapterError(
+                error_type=AdapterErrorType.TRANSPORT,
+                message=f"HTTP {exc.status_code}: {exc.message}",
+                source_name=_SOURCE_NAME,
+                details={"status_code": exc.status_code, "url": exc.url},
+                retryable=exc.retryable,
+            )
+        if isinstance(exc, TimeoutError):
+            return AdapterError(
+                error_type=AdapterErrorType.TIMEOUT,
+                message=f"Timeout: {exc}",
+                source_name=_SOURCE_NAME,
+                details={"identifier": identifier},
+                retryable=True,
+            )
+        return AdapterError(
+            error_type=AdapterErrorType.UNKNOWN,
+            message=f"{type(exc).__name__}: {exc}",
+            source_name=_SOURCE_NAME,
+            details={"identifier": identifier},
+            retryable=False,
+        )

--- a/services/adapters/wikipedia.py
+++ b/services/adapters/wikipedia.py
@@ -11,6 +11,7 @@ its parsing functions and wraps the HTTP layer via the injectable
 """
 from __future__ import annotations
 
+import json
 import re
 import urllib.parse
 from typing import Any, Optional
@@ -19,6 +20,7 @@ from services.adapters.base import (
     AdapterError,
     AdapterErrorType,
     AdapterResult,
+    AdapterSearchResult,
     CareerEntry,
     PlayerSourceAdapter,
 )
@@ -64,7 +66,7 @@ class WikipediaAdapter(PlayerSourceAdapter):
         try:
             wikitext = self._fetch_wikitext(identifier)
         except Exception as exc:
-            result.errors.append(self._error_from_exception(exc, identifier))
+            result.errors.append(self._error_from_exception(exc, identifier, phase="fetch"))
             return result
 
         if wikitext is None:
@@ -115,8 +117,9 @@ class WikipediaAdapter(PlayerSourceAdapter):
         result.success = bool(result.player_name or result.career)
         return result
 
-    def search_player(self, query: str, limit: int = 5) -> list[str]:
+    def search_player(self, query: str, limit: int = 5) -> AdapterSearchResult:
         """Search for page titles matching a query on it.wikipedia.org."""
+        result = AdapterSearchResult(source_name=_SOURCE_NAME, query=query)
         url = (
             _API
             + "?action=query&list=search&srsearch="
@@ -126,12 +129,22 @@ class WikipediaAdapter(PlayerSourceAdapter):
         try:
             resp = self._http.get(url)
             data = resp.json()
-            return [
+            if not isinstance(data, dict):
+                raise ValueError("Risposta API Wikipedia non valida: atteso dizionario JSON")
+            search_items = data.get("query", {}).get("search", [])
+            if not isinstance(search_items, list):
+                raise ValueError("Risposta API Wikipedia non valida: 'search' non è una lista")
+            result.identifiers = [
                 hit["title"]
-                for hit in data.get("query", {}).get("search", [])
+                for hit in search_items
+                if isinstance(hit, dict) and "title" in hit
             ]
-        except Exception:
-            return []
+            result.success = True
+            return result
+        except Exception as exc:
+            result.success = False
+            result.errors.append(self._error_from_exception(exc, query, phase="search"))
+            return result
 
     # ── HTTP layer ───────────────────────────────────────────────────────
 
@@ -145,10 +158,18 @@ class WikipediaAdapter(PlayerSourceAdapter):
         )
         resp = self._http.get(url)
         data = resp.json()
-
+        if not isinstance(data, dict):
+            raise ValueError("Risposta MediaWiki non valida: atteso oggetto JSON")
+        if "error" in data and isinstance(data["error"], dict):
+            if data["error"].get("code") in ("missingtitle", "nosuchpageid"):
+                return None
+            raise ValueError(f"MediaWiki API error: {data['error'].get('info', 'Unknown error')}")
         if "parse" not in data:
             return None
-        return data["parse"]["wikitext"]
+        parse_obj = data["parse"]
+        if not isinstance(parse_obj, dict) or "wikitext" not in parse_obj:
+            raise ValueError("Risposta MediaWiki non valida: wikitext mancante o non valido")
+        return str(parse_obj["wikitext"])
 
     # ── Wikitext parsing (adapted from scripts/wikipedia/wiki.py) ────────
 
@@ -362,15 +383,30 @@ class WikipediaAdapter(PlayerSourceAdapter):
 
     # ── Error helpers ────────────────────────────────────────────────────
 
-    def _error_from_exception(self, exc: Exception, identifier: str) -> AdapterError:
+    @classmethod
+    def _error_from_exception(
+        cls,
+        exc: Exception,
+        identifier: str,
+        *,
+        phase: str = "response_parsing",
+    ) -> AdapterError:
         """Convert an exception into a structured ``AdapterError``."""
+        if isinstance(exc, (json.JSONDecodeError, ValueError, TypeError)):
+            return AdapterError(
+                error_type=AdapterErrorType.PARSE,
+                message=f"Risposta non valida o malformata per {identifier}: {exc}",
+                source_name=_SOURCE_NAME,
+                details={"phase": phase, "identifier": identifier, "exception": str(exc)},
+                retryable=False,
+            )
         if isinstance(exc, HttpError):
             if exc.status_code == 404:
                 return AdapterError(
                     error_type=AdapterErrorType.NOT_FOUND,
                     message=f"Pagina non trovata: {identifier}",
                     source_name=_SOURCE_NAME,
-                    details={"status_code": exc.status_code, "url": exc.url},
+                    details={"status_code": exc.status_code, "url": exc.url, "phase": phase},
                     retryable=False,
                 )
             if exc.status_code == 429:
@@ -378,14 +414,14 @@ class WikipediaAdapter(PlayerSourceAdapter):
                     error_type=AdapterErrorType.RATE_LIMIT,
                     message=f"Rate limited: {identifier}",
                     source_name=_SOURCE_NAME,
-                    details={"status_code": exc.status_code, "url": exc.url},
+                    details={"status_code": exc.status_code, "url": exc.url, "phase": phase},
                     retryable=True,
                 )
             return AdapterError(
                 error_type=AdapterErrorType.TRANSPORT,
                 message=f"HTTP {exc.status_code}: {exc.message}",
                 source_name=_SOURCE_NAME,
-                details={"status_code": exc.status_code, "url": exc.url},
+                details={"status_code": exc.status_code, "url": exc.url, "phase": phase},
                 retryable=exc.retryable,
             )
         if isinstance(exc, TimeoutError):
@@ -393,13 +429,13 @@ class WikipediaAdapter(PlayerSourceAdapter):
                 error_type=AdapterErrorType.TIMEOUT,
                 message=f"Timeout: {exc}",
                 source_name=_SOURCE_NAME,
-                details={"identifier": identifier},
+                details={"identifier": identifier, "phase": phase},
                 retryable=True,
             )
         return AdapterError(
             error_type=AdapterErrorType.UNKNOWN,
             message=f"{type(exc).__name__}: {exc}",
             source_name=_SOURCE_NAME,
-            details={"identifier": identifier},
+            details={"identifier": identifier, "phase": phase},
             retryable=False,
         )

--- a/tests/fixtures/wikidata_entity_minimal.json
+++ b/tests/fixtures/wikidata_entity_minimal.json
@@ -1,0 +1,26 @@
+{
+  "entities": {
+    "Q99999999": {
+      "type": "item",
+      "id": "Q99999999",
+      "labels": {
+        "en": {"language": "en", "value": "Unknown Player"}
+      },
+      "aliases": {},
+      "claims": {
+        "P569": [
+          {
+            "mainsnak": {
+              "snaktype": "value",
+              "property": "P569",
+              "datavalue": {
+                "type": "time",
+                "value": {"time": "+1995-03-15T00:00:00Z", "precision": 11}
+              }
+            }
+          }
+        ]
+      }
+    }
+  }
+}

--- a/tests/fixtures/wikidata_entity_totti.json
+++ b/tests/fixtures/wikidata_entity_totti.json
@@ -84,10 +84,10 @@
                   }
                 }
               ],
-              "P1642": [
+              "P1350": [
                 {
                   "snaktype": "value",
-                  "property": "P1642",
+                  "property": "P1350",
                   "datavalue": {
                     "type": "quantity",
                     "value": {"amount": "+619", "unit": "1"}

--- a/tests/fixtures/wikidata_entity_totti.json
+++ b/tests/fixtures/wikidata_entity_totti.json
@@ -1,0 +1,113 @@
+{
+  "entities": {
+    "Q170984": {
+      "type": "item",
+      "id": "Q170984",
+      "labels": {
+        "it": {"language": "it", "value": "Francesco Totti"},
+        "en": {"language": "en", "value": "Francesco Totti"}
+      },
+      "aliases": {
+        "it": [
+          {"language": "it", "value": "totti"},
+          {"language": "it", "value": "er pupone"}
+        ],
+        "en": [
+          {"language": "en", "value": "Totti"}
+        ]
+      },
+      "claims": {
+        "P569": [
+          {
+            "mainsnak": {
+              "snaktype": "value",
+              "property": "P569",
+              "datavalue": {
+                "type": "time",
+                "value": {"time": "+1976-09-27T00:00:00Z", "precision": 11}
+              }
+            }
+          }
+        ],
+        "P27": [
+          {
+            "mainsnak": {
+              "snaktype": "value",
+              "property": "P27",
+              "datavalue": {
+                "type": "wikibase-entityid",
+                "value": {"entity-type": "item", "id": "Q38"}
+              }
+            }
+          }
+        ],
+        "P413": [
+          {
+            "mainsnak": {
+              "snaktype": "value",
+              "property": "P413",
+              "datavalue": {
+                "type": "wikibase-entityid",
+                "value": {"entity-type": "item", "id": "Q193592"}
+              }
+            }
+          }
+        ],
+        "P54": [
+          {
+            "mainsnak": {
+              "snaktype": "value",
+              "property": "P54",
+              "datavalue": {
+                "type": "wikibase-entityid",
+                "value": {"entity-type": "item", "id": "Q2565"}
+              }
+            },
+            "qualifiers": {
+              "P580": [
+                {
+                  "snaktype": "value",
+                  "property": "P580",
+                  "datavalue": {
+                    "type": "time",
+                    "value": {"time": "+1993-01-01T00:00:00Z", "precision": 9}
+                  }
+                }
+              ],
+              "P582": [
+                {
+                  "snaktype": "value",
+                  "property": "P582",
+                  "datavalue": {
+                    "type": "time",
+                    "value": {"time": "+2017-01-01T00:00:00Z", "precision": 9}
+                  }
+                }
+              ],
+              "P1642": [
+                {
+                  "snaktype": "value",
+                  "property": "P1642",
+                  "datavalue": {
+                    "type": "quantity",
+                    "value": {"amount": "+619", "unit": "1"}
+                  }
+                }
+              ],
+              "P1351": [
+                {
+                  "snaktype": "value",
+                  "property": "P1351",
+                  "datavalue": {
+                    "type": "quantity",
+                    "value": {"amount": "+250", "unit": "1"}
+                  }
+                }
+              ]
+            }
+          }
+        ]
+      }
+    }
+  }
+}

--- a/tests/fixtures/wikipedia_wikitext_loans.txt
+++ b/tests/fixtures/wikipedia_wikitext_loans.txt
@@ -1,0 +1,19 @@
+{{Bio
+|Nome = Jón
+|Cognome = Daði Böðvarsson
+|AnnoNascita = 1992
+|Nazionalità = islandese
+}}
+
+{{Sportivo
+|ruolo = Attaccante
+|codicenazione = {{ISL}}
+|squadre = {{Carriera sportivo
+|sport = Calcio
+|2010-2013|[[Selfoss (calcio)|Selfoss]]|45 (12)
+|2013-2015|[[Viking FK|Viking]]|50 (18)
+|2015-2016|→ [[1. FC Kaiserslautern|Kaiserslautern]]|28 (5)
+|2016-2019|[[Wolverhampton Wanderers F.C.|Wolverhampton]]|48 (5)
+|2019-2021|[[Millwall F.C.|Millwall]]|62 (10)
+}}
+}}

--- a/tests/fixtures/wikipedia_wikitext_minimal.txt
+++ b/tests/fixtures/wikipedia_wikitext_minimal.txt
@@ -1,0 +1,9 @@
+{{Bio
+|Nome = Test
+|Cognome = Player
+|AnnoNascita = 1990
+}}
+
+{{Sportivo
+|ruolo = Difensore
+}}

--- a/tests/fixtures/wikipedia_wikitext_totti.txt
+++ b/tests/fixtures/wikipedia_wikitext_totti.txt
@@ -1,0 +1,28 @@
+{{Bio
+|Nome = Francesco
+|Cognome = Totti
+|Sesso = M
+|LuogoNascita = Roma
+|GiornoMeseNascita = 27 settembre
+|AnnoNascita = 1976
+|Nazionalità = italiano
+|Attività = calciatore
+|PostNazionalità = , di ruolo [[attaccante]]
+}}
+
+{{Sportivo
+|ruolo = Attaccante
+|codicenazione = {{ITA}}
+|squadre = {{Carriera sportivo
+|sport = Calcio
+|pos = Attaccante
+|aggiornato =
+|1992-1993|{{Calcio Roma}}|4 (0)
+|1993-2017|{{Calcio Roma}}|619 (250)
+}}
+|nazionale = {{Carriera sportivo nazionale
+|1992-1993|{{Naz ITA Under-16}}|3 (1)
+|1994-1996|{{Naz ITA Under-21}}|10 (2)
+|1998-2006|{{Naz ITA}}|58 (9)
+}}
+}}

--- a/tests/test_adapters.py
+++ b/tests/test_adapters.py
@@ -15,6 +15,7 @@ from services.adapters.base import (
     AdapterError,
     AdapterErrorType,
     AdapterResult,
+    AdapterSearchResult,
     PlayerSourceAdapter,
 )
 from services.adapters.candidate_integration import (
@@ -130,6 +131,20 @@ class TestAdapterContract:
         d = err.to_dict()
         assert d["error_type"] == "transport"
         assert d["retryable"] is True
+
+    def test_adapter_search_result_serialization(self):
+        res = AdapterSearchResult(
+            source_name="wikipedia",
+            query="Totti",
+            identifiers=["Francesco Totti"],
+            success=True,
+        )
+        d = res.to_dict()
+        assert d["source_name"] == "wikipedia"
+        assert d["query"] == "Totti"
+        assert d["identifiers"] == ["Francesco Totti"]
+        assert d["success"] is True
+        assert d["errors"] == []
 
 
 # ═══════════════════════════════════════════════════════════════════════════
@@ -349,11 +364,24 @@ class TestWikipediaAdapter:
         result = adapter.fetch_player("BadPage")
 
         assert result.success is False
-        assert len(result.errors) >= 1
+        assert len(result.errors) == 1
+        assert result.errors[0].error_type == AdapterErrorType.PARSE
+        assert result.errors[0].details.get("phase") in ("response_parsing", "fetch")
+
+    def test_fetch_invalid_json_structure(self):
+        adapter, client = self._make_adapter()
+        client.configure("api.php", HttpResponse(200, json.dumps(["invalid", "array"])))
+
+        result = adapter.fetch_player("BadPage")
+
+        assert result.success is False
+        assert len(result.errors) == 1
+        assert result.errors[0].error_type == AdapterErrorType.PARSE
+        assert result.errors[0].details.get("phase") in ("response_parsing", "fetch")
 
     # ── Search ───────────────────────────────────────────────────────────
 
-    def test_search_returns_titles(self):
+    def test_search_wikipedia_success_with_results(self):
         adapter, client = self._make_adapter()
         search_response = HttpResponse(200, json.dumps({
             "query": {"search": [
@@ -363,17 +391,76 @@ class TestWikipediaAdapter:
         }))
         client.configure("api.php", search_response)
 
-        titles = adapter.search_player("Totti")
+        search_res = adapter.search_player("Totti")
 
-        assert len(titles) == 2
-        assert "Francesco Totti" in titles
+        assert search_res.success is True
+        assert search_res.source_name == "wikipedia"
+        assert search_res.query == "Totti"
+        assert len(search_res.identifiers) == 2
+        assert "Francesco Totti" in search_res.identifiers
+        assert search_res.errors == []
 
-    def test_search_returns_empty_on_error(self):
+    def test_search_wikipedia_success_zero_results(self):
         adapter, client = self._make_adapter()
-        client.configure("api.php", HttpError(500, "error", url="https://wiki", retryable=True))
+        search_response = HttpResponse(200, json.dumps({
+            "query": {"search": []}
+        }))
+        client.configure("api.php", search_response)
 
-        titles = adapter.search_player("Totti")
-        assert titles == []
+        search_res = adapter.search_player("NonExistentPlayer12345")
+
+        assert search_res.success is True
+        assert search_res.source_name == "wikipedia"
+        assert search_res.identifiers == []
+        assert search_res.errors == []
+
+    def test_search_wikipedia_timeout(self):
+        adapter, client = self._make_adapter()
+        client.configure("api.php", TimeoutError("Request timed out"))
+
+        search_res = adapter.search_player("Totti")
+
+        assert search_res.success is False
+        assert search_res.identifiers == []
+        assert len(search_res.errors) == 1
+        assert search_res.errors[0].error_type == AdapterErrorType.TIMEOUT
+        assert search_res.errors[0].retryable is True
+
+    def test_search_wikipedia_429_rate_limit(self):
+        adapter, client = self._make_adapter()
+        client.configure("api.php", HttpError(429, "Too Many Requests", url="https://wiki", retryable=True))
+
+        search_res = adapter.search_player("Totti")
+
+        assert search_res.success is False
+        assert search_res.identifiers == []
+        assert len(search_res.errors) == 1
+        assert search_res.errors[0].error_type == AdapterErrorType.RATE_LIMIT
+        assert search_res.errors[0].retryable is True
+
+    def test_search_wikipedia_http_failure(self):
+        adapter, client = self._make_adapter()
+        client.configure("api.php", HttpError(500, "Internal Server Error", url="https://wiki", retryable=True))
+
+        search_res = adapter.search_player("Totti")
+
+        assert search_res.success is False
+        assert search_res.identifiers == []
+        assert len(search_res.errors) == 1
+        assert search_res.errors[0].error_type == AdapterErrorType.TRANSPORT
+        assert search_res.errors[0].retryable is True
+
+    def test_search_wikipedia_malformed_json(self):
+        adapter, client = self._make_adapter()
+        client.configure("api.php", HttpResponse(200, "not json at all"))
+
+        search_res = adapter.search_player("Totti")
+
+        assert search_res.success is False
+        assert search_res.identifiers == []
+        assert len(search_res.errors) == 1
+        assert search_res.errors[0].error_type == AdapterErrorType.PARSE
+        assert search_res.errors[0].retryable is False
 
 
 # ═══════════════════════════════════════════════════════════════════════════
@@ -512,7 +599,116 @@ class TestWikidataAdapter:
         result = adapter.fetch_player("Q999")
 
         assert result.success is False
-        assert len(result.errors) >= 1
+        assert len(result.errors) == 1
+        assert result.errors[0].error_type == AdapterErrorType.PARSE
+        assert result.errors[0].details.get("phase") in ("response_parsing", "fetch")
+
+    def test_fetch_invalid_json_structure(self):
+        adapter, client = self._make_adapter()
+        client.configure("EntityData", HttpResponse(200, json.dumps(["not", "a", "dict"])))
+
+        result = adapter.fetch_player("Q999")
+
+        assert result.success is False
+        assert len(result.errors) == 1
+        assert result.errors[0].error_type == AdapterErrorType.PARSE
+        assert result.errors[0].details.get("phase") in ("response_parsing", "fetch")
+
+    def test_wikidata_apps_p1350_goals_p1351_not_p1642(self):
+        """Regression test: P1350 populates apps, P1351 populates goals,
+        and P1642 is NOT interpreted as appearances.
+        """
+        adapter, client = self._make_adapter()
+        entity_data = {
+            "entities": {
+                "Q12345": {
+                    "id": "Q12345",
+                    "labels": {"it": {"language": "it", "value": "Test Player"}},
+                    "claims": {
+                        "P54": [
+                            {
+                                "mainsnak": {
+                                    "datavalue": {
+                                        "type": "wikibase-entityid",
+                                        "value": {"id": "Q99"},
+                                    }
+                                },
+                                "qualifiers": {
+                                    "P1350": [
+                                        {
+                                            "snaktype": "value",
+                                            "property": "P1350",
+                                            "datavalue": {"type": "quantity", "value": {"amount": "+42", "unit": "1"}},
+                                        }
+                                    ],
+                                    "P1351": [
+                                        {
+                                            "snaktype": "value",
+                                            "property": "P1351",
+                                            "datavalue": {"type": "quantity", "value": {"amount": "+15", "unit": "1"}},
+                                        }
+                                    ],
+                                    "P1642": [
+                                        {
+                                            "snaktype": "value",
+                                            "property": "P1642",
+                                            "datavalue": {"type": "quantity", "value": {"amount": "+999", "unit": "1"}},
+                                        }
+                                    ],
+                                },
+                            }
+                        ]
+                    },
+                }
+            }
+        }
+        client.configure("EntityData", HttpResponse(200, json.dumps(entity_data)))
+
+        result = adapter.fetch_player("Q12345")
+
+        assert result.success is True
+        assert len(result.career) == 1
+        stop = result.career[0]
+        assert stop["apps"] == 42, f"Expected 42 apps from P1350, got {stop['apps']}"
+        assert stop["goals"] == 15, f"Expected 15 goals from P1351, got {stop['goals']}"
+        assert stop["apps"] != 999, "P1642 must not be interpreted as appearances"
+
+        # Separate case: Entity with ONLY P1642 and no P1350
+        entity_p1642_only = {
+            "entities": {
+                "Q54321": {
+                    "id": "Q54321",
+                    "labels": {"it": {"language": "it", "value": "Old Transaction Player"}},
+                    "claims": {
+                        "P54": [
+                            {
+                                "mainsnak": {
+                                    "datavalue": {
+                                        "type": "wikibase-entityid",
+                                        "value": {"id": "Q99"},
+                                    }
+                                },
+                                "qualifiers": {
+                                    "P1642": [
+                                        {
+                                            "snaktype": "value",
+                                            "property": "P1642",
+                                            "datavalue": {"type": "quantity", "value": {"amount": "+500", "unit": "1"}},
+                                        }
+                                    ],
+                                },
+                            }
+                        ]
+                    },
+                }
+            }
+        }
+        client.configure("EntityData", HttpResponse(200, json.dumps(entity_p1642_only)))
+
+        result2 = adapter.fetch_player("Q54321")
+        assert result2.success is True
+        assert len(result2.career) == 1
+        assert result2.career[0]["apps"] is None, "When P1350 is absent, apps must be None (P1642 ignored)"
 
     def test_entity_missing_from_response(self):
         adapter, client = self._make_adapter()
@@ -525,22 +721,82 @@ class TestWikidataAdapter:
 
     # ── Search ───────────────────────────────────────────────────────────
 
-    def test_search_returns_qids(self):
+    def test_search_wikidata_success_with_results(self):
         adapter, client = self._make_adapter()
         search_resp = HttpResponse(200, json.dumps({
             "search": [{"id": "Q170984"}, {"id": "Q12345"}]
         }))
         client.configure("api.php", search_resp)
 
-        qids = adapter.search_player("Totti")
-        assert "Q170984" in qids
+        search_res = adapter.search_player("Totti")
 
-    def test_search_returns_empty_on_error(self):
+        assert search_res.success is True
+        assert search_res.source_name == "wikidata"
+        assert search_res.query == "Totti"
+        assert search_res.identifiers == ["Q170984", "Q12345"]
+        assert search_res.errors == []
+
+    def test_search_wikidata_success_zero_results(self):
+        adapter, client = self._make_adapter()
+        search_resp = HttpResponse(200, json.dumps({
+            "search": []
+        }))
+        client.configure("api.php", search_resp)
+
+        search_res = adapter.search_player("NonExistentPlayer12345")
+
+        assert search_res.success is True
+        assert search_res.source_name == "wikidata"
+        assert search_res.identifiers == []
+        assert search_res.errors == []
+
+    def test_search_wikidata_timeout(self):
+        adapter, client = self._make_adapter()
+        client.configure("api.php", TimeoutError("timed out"))
+
+        search_res = adapter.search_player("Totti")
+
+        assert search_res.success is False
+        assert search_res.identifiers == []
+        assert len(search_res.errors) == 1
+        assert search_res.errors[0].error_type == AdapterErrorType.TIMEOUT
+        assert search_res.errors[0].retryable is True
+
+    def test_search_wikidata_429_rate_limit(self):
+        adapter, client = self._make_adapter()
+        client.configure("api.php", HttpError(429, "Rate limited", url="https://wikidata", retryable=True))
+
+        search_res = adapter.search_player("Totti")
+
+        assert search_res.success is False
+        assert search_res.identifiers == []
+        assert len(search_res.errors) == 1
+        assert search_res.errors[0].error_type == AdapterErrorType.RATE_LIMIT
+        assert search_res.errors[0].retryable is True
+
+    def test_search_wikidata_http_failure(self):
         adapter, client = self._make_adapter()
         client.configure("api.php", HttpError(500, "error", url="https://wikidata", retryable=True))
 
-        qids = adapter.search_player("Totti")
-        assert qids == []
+        search_res = adapter.search_player("Totti")
+
+        assert search_res.success is False
+        assert search_res.identifiers == []
+        assert len(search_res.errors) == 1
+        assert search_res.errors[0].error_type == AdapterErrorType.TRANSPORT
+        assert search_res.errors[0].retryable is True
+
+    def test_search_wikidata_malformed_json(self):
+        adapter, client = self._make_adapter()
+        client.configure("api.php", HttpResponse(200, "not json at all"))
+
+        search_res = adapter.search_player("Totti")
+
+        assert search_res.success is False
+        assert search_res.identifiers == []
+        assert len(search_res.errors) == 1
+        assert search_res.errors[0].error_type == AdapterErrorType.PARSE
+        assert search_res.errors[0].retryable is False
 
 
 # ═══════════════════════════════════════════════════════════════════════════
@@ -611,8 +867,13 @@ class TestCandidateIntegration:
         assert candidate.state_history[0].to_state == CandidateState.FETCHED
         assert "wikipedia" in (candidate.state_history[0].actor or "")
 
-    def test_partial_result_goes_to_review(self):
-        """Missing career (<2 stops) should transition to REVIEW_REQUIRED."""
+    def test_partial_result_transitions_to_fetched_and_preserves_errors(self):
+        """A successful fetch with partial/sparse data or non-fatal warnings
+        must transition DISCOVERED → FETCHED deterministically.
+
+        Downstream normalization and validation (#26) will determine whether
+        the candidate later transitions to REVIEW_REQUIRED.
+        """
         candidate = self._make_candidate()
         result = AdapterResult(
             source_name="wikipedia",
@@ -620,14 +881,25 @@ class TestCandidateIntegration:
             success=True,
             player_name="Partial Player",
             career=[{"team": "Solo Club", "start_year": 2020, "end_year": 2024}],
+            errors=[
+                AdapterError(
+                    error_type=AdapterErrorType.PARSE,
+                    message="Warning: infobox missing birthplace",
+                    source_name="wikipedia",
+                    retryable=False,
+                )
+            ],
         )
 
         populate_candidate_from_result(candidate, result)
 
-        # DISCOVERED → REVIEW_REQUIRED is not directly allowed
-        # but DISCOVERED → FETCHED is, then future steps go to REVIEW_REQUIRED
-        # Let's check what actually happened based on the allowed transitions
-        assert candidate.status in (CandidateState.FETCHED, CandidateState.REVIEW_REQUIRED)
+        assert candidate.status == CandidateState.FETCHED
+        assert candidate.full_name == "Partial Player"
+        assert len(candidate.career) == 1
+        assert len(candidate.errors) == 1
+        assert candidate.errors[0].error_type == "parse"
+        assert candidate.errors[0].message == "Warning: infobox missing birthplace"
+        assert candidate.retry_count == 0  # non-fatal warning does not increment retries
 
     def test_failed_result_records_errors(self):
         candidate = self._make_candidate()

--- a/tests/test_adapters.py
+++ b/tests/test_adapters.py
@@ -1,0 +1,898 @@
+"""Comprehensive deterministic tests for the multi-source adapter layer (#14).
+
+All tests use fixture files and a fake HttpClient — no real network calls.
+No writes to data/players.json.  No dependency on Wikipedia/Wikidata availability.
+"""
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from typing import Any, Optional
+
+import pytest
+
+from services.adapters.base import (
+    AdapterError,
+    AdapterErrorType,
+    AdapterResult,
+    PlayerSourceAdapter,
+)
+from services.adapters.candidate_integration import (
+    populate_candidate_from_result,
+    record_adapter_failure,
+)
+from services.adapters.http_client import HttpClient, HttpError, HttpResponse, UrllibHttpClient
+from services.adapters.wikidata import WikidataAdapter
+from services.adapters.wikipedia import WikipediaAdapter
+from services.candidate_player import (
+    CandidatePlayer,
+    CandidateState,
+    make_candidate_id,
+)
+
+# ── Fixture paths ────────────────────────────────────────────────────────
+
+_FIXTURES = Path(__file__).parent / "fixtures"
+
+
+def _load_fixture(name: str) -> str:
+    return (_FIXTURES / name).read_text(encoding="utf-8")
+
+
+def _load_json_fixture(name: str) -> dict[str, Any]:
+    return json.loads(_load_fixture(name))
+
+
+# ── Fake HTTP client ─────────────────────────────────────────────────────
+
+
+class FakeHttpClient:
+    """Test double for HttpClient — returns pre-configured responses."""
+
+    def __init__(self) -> None:
+        self.responses: dict[str, HttpResponse | Exception] = {}
+        self.requests: list[str] = []
+
+    def configure(self, url_fragment: str, response: HttpResponse | Exception) -> None:
+        """Register a response for any URL containing ``url_fragment``."""
+        self.responses[url_fragment] = response
+
+    def get(self, url: str, *, timeout: int = 30) -> HttpResponse:
+        self.requests.append(url)
+        for fragment, response in self.responses.items():
+            if fragment in url:
+                if isinstance(response, Exception):
+                    raise response
+                return response
+        raise HttpError(
+            status_code=404,
+            message="Not configured in FakeHttpClient",
+            url=url,
+            retryable=False,
+        )
+
+
+def _wiki_api_response(wikitext: str) -> HttpResponse:
+    """Wrap wikitext in a MediaWiki API parse response."""
+    return HttpResponse(
+        status_code=200,
+        body=json.dumps({"parse": {"wikitext": wikitext}}),
+    )
+
+
+def _wikidata_entity_response(fixture_name: str) -> HttpResponse:
+    """Load a Wikidata entity fixture and wrap in HttpResponse."""
+    data = _load_fixture(fixture_name)
+    return HttpResponse(status_code=200, body=data)
+
+
+# ═══════════════════════════════════════════════════════════════════════════
+# CONTRACT TESTS
+# ═══════════════════════════════════════════════════════════════════════════
+
+
+class TestAdapterContract:
+    """Verify the abstract contract is enforced."""
+
+    def test_cannot_instantiate_abc(self):
+        with pytest.raises(TypeError):
+            PlayerSourceAdapter()  # type: ignore[abstract]
+
+    def test_wikipedia_adapter_has_source_name(self):
+        adapter = WikipediaAdapter(http_client=FakeHttpClient())
+        assert adapter.source_name == "wikipedia"
+
+    def test_wikidata_adapter_has_source_name(self):
+        adapter = WikidataAdapter(http_client=FakeHttpClient())
+        assert adapter.source_name == "wikidata"
+
+    def test_adapter_result_serialization(self):
+        result = AdapterResult(
+            source_name="test",
+            source_id="id1",
+            success=True,
+            player_name="Test Player",
+            career=[{"team": "Roma", "start_year": 1993, "end_year": 2017}],
+        )
+        d = result.to_dict()
+        assert d["source_name"] == "test"
+        assert d["success"] is True
+        assert len(d["career"]) == 1
+
+    def test_adapter_error_serialization(self):
+        err = AdapterError(
+            error_type=AdapterErrorType.TRANSPORT,
+            message="connection reset",
+            source_name="wikipedia",
+            details={"status_code": 500},
+            retryable=True,
+        )
+        d = err.to_dict()
+        assert d["error_type"] == "transport"
+        assert d["retryable"] is True
+
+
+# ═══════════════════════════════════════════════════════════════════════════
+# HTTP CLIENT TESTS
+# ═══════════════════════════════════════════════════════════════════════════
+
+
+class TestHttpClient:
+    """Tests for the HTTP client protocol and error types."""
+
+    def test_fake_client_implements_protocol(self):
+        assert isinstance(FakeHttpClient(), HttpClient)
+
+    def test_urllib_client_implements_protocol(self):
+        assert isinstance(UrllibHttpClient(), HttpClient)
+
+    def test_http_response_json_parsing(self):
+        resp = HttpResponse(status_code=200, body='{"key": "value"}')
+        assert resp.json() == {"key": "value"}
+
+    def test_http_response_invalid_json(self):
+        resp = HttpResponse(status_code=200, body="not json")
+        with pytest.raises(json.JSONDecodeError):
+            resp.json()
+
+    def test_http_error_attributes(self):
+        err = HttpError(
+            status_code=429,
+            message="Too Many Requests",
+            url="https://example.com",
+            retryable=True,
+        )
+        assert err.status_code == 429
+        assert err.retryable is True
+        assert "429" in str(err)
+
+    def test_fake_client_unconfigured_url(self):
+        client = FakeHttpClient()
+        with pytest.raises(HttpError) as exc_info:
+            client.get("https://unknown.example.com")
+        assert exc_info.value.status_code == 404
+
+    def test_fake_client_records_requests(self):
+        client = FakeHttpClient()
+        client.configure("example", HttpResponse(200, "ok"))
+        client.get("https://example.com/test")
+        assert len(client.requests) == 1
+        assert "example" in client.requests[0]
+
+
+# ═══════════════════════════════════════════════════════════════════════════
+# WIKIPEDIA ADAPTER TESTS
+# ═══════════════════════════════════════════════════════════════════════════
+
+
+class TestWikipediaAdapter:
+    """Tests for the Wikipedia adapter."""
+
+    def _make_adapter(self, client: Optional[FakeHttpClient] = None) -> tuple[WikipediaAdapter, FakeHttpClient]:
+        c = client or FakeHttpClient()
+        return WikipediaAdapter(http_client=c), c
+
+    # ── Successful parsing ───────────────────────────────────────────────
+
+    def test_fetch_totti_career(self):
+        """Full career parsing from the Totti fixture."""
+        wikitext = _load_fixture("wikipedia_wikitext_totti.txt")
+        adapter, client = self._make_adapter()
+        client.configure("api.php", _wiki_api_response(wikitext))
+
+        result = adapter.fetch_player("Francesco Totti")
+
+        assert result.success is True
+        assert result.source_name == "wikipedia"
+        assert result.source_id == "Francesco Totti"
+        assert result.player_name == "Francesco Totti"
+        assert result.position == "Attaccante"
+        assert result.birth_year == 1976
+        assert result.nationality == "ITA"
+        assert result.nationality_raw == "italiano"
+        assert len(result.career) >= 1
+        # Check a career stop
+        roma_stop = result.career[-1]
+        assert roma_stop["team"] == "Roma"
+        assert roma_stop["start_year"] == 1993
+        assert roma_stop["end_year"] == 2017
+        assert roma_stop["apps"] == 619
+        assert roma_stop["goals"] == 250
+
+    def test_fetch_with_loans_and_unicode(self):
+        """Non-ASCII player name, loan markers, wiki links."""
+        wikitext = _load_fixture("wikipedia_wikitext_loans.txt")
+        adapter, client = self._make_adapter()
+        client.configure("api.php", _wiki_api_response(wikitext))
+
+        result = adapter.fetch_player("Jón Daði Böðvarsson")
+
+        assert result.success is True
+        assert result.player_name == "Jón Daði Böðvarsson"
+        assert result.birth_year == 1992
+        assert result.position == "Attaccante"
+
+        # At least one loan stop
+        loans = [c for c in result.career if c.get("loan")]
+        assert len(loans) >= 1
+        assert loans[0]["team"] == "Kaiserslautern"
+
+        # Wiki links should be preserved
+        linked = [c for c in result.career if c.get("link")]
+        assert len(linked) >= 1
+
+    def test_fetch_minimal_profile(self):
+        """Minimal infobox with no career — returns partial data."""
+        wikitext = _load_fixture("wikipedia_wikitext_minimal.txt")
+        adapter, client = self._make_adapter()
+        client.configure("api.php", _wiki_api_response(wikitext))
+
+        result = adapter.fetch_player("Test Player")
+
+        # Minimal fixture has a name but no career
+        assert result.player_name == "Test Player"
+        assert result.position == "Difensore"
+        assert result.birth_year == 1990
+        assert result.career == []
+
+    def test_fetch_no_infobox(self):
+        """Page without a recognized infobox."""
+        adapter, client = self._make_adapter()
+        client.configure("api.php", _wiki_api_response("Just some text without infobox."))
+
+        result = adapter.fetch_player("Random Page")
+
+        assert result.success is False
+        assert result.player_name is None
+        assert result.career == []
+
+    # ── Raw payload preservation ─────────────────────────────────────────
+
+    def test_raw_payload_contains_wikitext(self):
+        wikitext = _load_fixture("wikipedia_wikitext_totti.txt")
+        adapter, client = self._make_adapter()
+        client.configure("api.php", _wiki_api_response(wikitext))
+
+        result = adapter.fetch_player("Francesco Totti")
+
+        assert "wikitext" in result.raw_payload
+        assert "Totti" in result.raw_payload["wikitext"]
+        assert "title" in result.raw_payload
+
+    def test_source_metadata_populated(self):
+        wikitext = _load_fixture("wikipedia_wikitext_totti.txt")
+        adapter, client = self._make_adapter()
+        client.configure("api.php", _wiki_api_response(wikitext))
+
+        result = adapter.fetch_player("Francesco Totti")
+
+        assert "retrieved_at" in result.source_metadata
+        assert "url" in result.source_metadata
+        assert "wikipedia.org" in result.source_metadata["url"]
+
+    # ── Error handling ───────────────────────────────────────────────────
+
+    def test_fetch_http_404(self):
+        adapter, client = self._make_adapter()
+        client.configure("api.php", HttpError(404, "Not Found", url="https://wiki", retryable=False))
+
+        result = adapter.fetch_player("Nonexistent Page")
+
+        assert result.success is False
+        assert len(result.errors) == 1
+        assert result.errors[0].error_type == AdapterErrorType.NOT_FOUND
+        assert result.errors[0].retryable is False
+
+    def test_fetch_http_429_rate_limit(self):
+        adapter, client = self._make_adapter()
+        client.configure("api.php", HttpError(429, "Too Many Requests", url="https://wiki", retryable=True))
+
+        result = adapter.fetch_player("Totti")
+
+        assert result.success is False
+        assert result.errors[0].error_type == AdapterErrorType.RATE_LIMIT
+        assert result.errors[0].retryable is True
+
+    def test_fetch_http_500_server_error(self):
+        adapter, client = self._make_adapter()
+        client.configure("api.php", HttpError(500, "Internal Server Error", url="https://wiki", retryable=True))
+
+        result = adapter.fetch_player("Totti")
+
+        assert result.success is False
+        assert result.errors[0].error_type == AdapterErrorType.TRANSPORT
+        assert result.errors[0].retryable is True
+
+    def test_fetch_timeout(self):
+        adapter, client = self._make_adapter()
+        client.configure("api.php", TimeoutError("timed out"))
+
+        result = adapter.fetch_player("Totti")
+
+        assert result.success is False
+        assert result.errors[0].error_type == AdapterErrorType.TIMEOUT
+        assert result.errors[0].retryable is True
+
+    def test_fetch_page_not_in_api_response(self):
+        adapter, client = self._make_adapter()
+        client.configure("api.php", HttpResponse(200, json.dumps({"error": {"code": "missingtitle"}})))
+
+        result = adapter.fetch_player("Missing")
+
+        assert result.success is False
+        assert any(e.error_type == AdapterErrorType.NOT_FOUND for e in result.errors)
+
+    def test_fetch_malformed_json(self):
+        adapter, client = self._make_adapter()
+        client.configure("api.php", HttpResponse(200, "not json at all"))
+
+        result = adapter.fetch_player("BadPage")
+
+        assert result.success is False
+        assert len(result.errors) >= 1
+
+    # ── Search ───────────────────────────────────────────────────────────
+
+    def test_search_returns_titles(self):
+        adapter, client = self._make_adapter()
+        search_response = HttpResponse(200, json.dumps({
+            "query": {"search": [
+                {"title": "Francesco Totti"},
+                {"title": "Totti (disambigua)"},
+            ]}
+        }))
+        client.configure("api.php", search_response)
+
+        titles = adapter.search_player("Totti")
+
+        assert len(titles) == 2
+        assert "Francesco Totti" in titles
+
+    def test_search_returns_empty_on_error(self):
+        adapter, client = self._make_adapter()
+        client.configure("api.php", HttpError(500, "error", url="https://wiki", retryable=True))
+
+        titles = adapter.search_player("Totti")
+        assert titles == []
+
+
+# ═══════════════════════════════════════════════════════════════════════════
+# WIKIDATA ADAPTER TESTS
+# ═══════════════════════════════════════════════════════════════════════════
+
+
+class TestWikidataAdapter:
+    """Tests for the Wikidata adapter."""
+
+    def _make_adapter(self, client: Optional[FakeHttpClient] = None) -> tuple[WikidataAdapter, FakeHttpClient]:
+        c = client or FakeHttpClient()
+        return WikidataAdapter(http_client=c), c
+
+    # ── Successful parsing ───────────────────────────────────────────────
+
+    def test_fetch_totti_entity(self):
+        """Full entity parsing from the Totti Wikidata fixture."""
+        adapter, client = self._make_adapter()
+        client.configure("EntityData", _wikidata_entity_response("wikidata_entity_totti.json"))
+
+        result = adapter.fetch_player("Q170984")
+
+        assert result.success is True
+        assert result.source_name == "wikidata"
+        assert result.source_id == "Q170984"
+        assert result.player_name == "Francesco Totti"
+        assert result.birth_year == 1976
+        assert result.nationality == "Q38"  # QID for Italy
+        assert result.position == "Attaccante"
+
+        # Career
+        assert len(result.career) >= 1
+        roma = result.career[0]
+        assert roma["team"] == "Q2565"  # QID for AS Roma
+        assert roma["start_year"] == 1993
+        assert roma["end_year"] == 2017
+        assert roma["apps"] == 619
+        assert roma["goals"] == 250
+
+    def test_fetch_entity_aliases(self):
+        """Aliases are extracted from multiple languages."""
+        adapter, client = self._make_adapter()
+        client.configure("EntityData", _wikidata_entity_response("wikidata_entity_totti.json"))
+
+        result = adapter.fetch_player("Q170984")
+
+        assert "totti" in result.aliases
+        assert "er pupone" in result.aliases
+
+    def test_fetch_minimal_entity(self):
+        """Minimal entity with sparse claims."""
+        adapter, client = self._make_adapter()
+        client.configure("EntityData", _wikidata_entity_response("wikidata_entity_minimal.json"))
+
+        result = adapter.fetch_player("Q99999999")
+
+        assert result.player_name == "Unknown Player"
+        assert result.birth_year == 1995
+        assert result.career == []
+        assert result.position is None
+        assert result.nationality is None
+
+    def test_qid_normalization(self):
+        """QIDs are normalized to uppercase."""
+        adapter, client = self._make_adapter()
+        client.configure("EntityData", _wikidata_entity_response("wikidata_entity_totti.json"))
+
+        result = adapter.fetch_player("q170984")
+        assert result.source_id == "Q170984"
+
+    def test_qid_from_url(self):
+        """QIDs can be extracted from a Wikidata URL."""
+        adapter, client = self._make_adapter()
+        client.configure("EntityData", _wikidata_entity_response("wikidata_entity_totti.json"))
+
+        result = adapter.fetch_player("https://www.wikidata.org/wiki/Q170984")
+        assert result.source_id == "Q170984"
+
+    # ── Raw payload preservation ─────────────────────────────────────────
+
+    def test_raw_payload_contains_entity(self):
+        adapter, client = self._make_adapter()
+        client.configure("EntityData", _wikidata_entity_response("wikidata_entity_totti.json"))
+
+        result = adapter.fetch_player("Q170984")
+
+        assert "entity" in result.raw_payload
+        assert "qid" in result.raw_payload
+        assert result.raw_payload["qid"] == "Q170984"
+
+    def test_source_metadata_populated(self):
+        adapter, client = self._make_adapter()
+        client.configure("EntityData", _wikidata_entity_response("wikidata_entity_totti.json"))
+
+        result = adapter.fetch_player("Q170984")
+
+        assert "retrieved_at" in result.source_metadata
+        assert "url" in result.source_metadata
+        assert "wikidata.org" in result.source_metadata["url"]
+
+    # ── Error handling ───────────────────────────────────────────────────
+
+    def test_fetch_http_404(self):
+        adapter, client = self._make_adapter()
+        client.configure("EntityData", HttpError(404, "Not Found", url="https://wikidata", retryable=False))
+
+        result = adapter.fetch_player("Q999")
+
+        assert result.success is False
+        assert result.errors[0].error_type == AdapterErrorType.NOT_FOUND
+
+    def test_fetch_http_429(self):
+        adapter, client = self._make_adapter()
+        client.configure("EntityData", HttpError(429, "Rate Limited", url="https://wikidata", retryable=True))
+
+        result = adapter.fetch_player("Q999")
+
+        assert result.success is False
+        assert result.errors[0].error_type == AdapterErrorType.RATE_LIMIT
+        assert result.errors[0].retryable is True
+
+    def test_fetch_timeout(self):
+        adapter, client = self._make_adapter()
+        client.configure("EntityData", TimeoutError("timed out"))
+
+        result = adapter.fetch_player("Q999")
+
+        assert result.success is False
+        assert result.errors[0].error_type == AdapterErrorType.TIMEOUT
+
+    def test_fetch_malformed_json(self):
+        adapter, client = self._make_adapter()
+        client.configure("EntityData", HttpResponse(200, "not json"))
+
+        result = adapter.fetch_player("Q999")
+
+        assert result.success is False
+        assert len(result.errors) >= 1
+
+    def test_entity_missing_from_response(self):
+        adapter, client = self._make_adapter()
+        client.configure("EntityData", HttpResponse(200, json.dumps({"entities": {}})))
+
+        result = adapter.fetch_player("Q12345")
+
+        assert result.success is False
+        assert any(e.error_type == AdapterErrorType.NOT_FOUND for e in result.errors)
+
+    # ── Search ───────────────────────────────────────────────────────────
+
+    def test_search_returns_qids(self):
+        adapter, client = self._make_adapter()
+        search_resp = HttpResponse(200, json.dumps({
+            "search": [{"id": "Q170984"}, {"id": "Q12345"}]
+        }))
+        client.configure("api.php", search_resp)
+
+        qids = adapter.search_player("Totti")
+        assert "Q170984" in qids
+
+    def test_search_returns_empty_on_error(self):
+        adapter, client = self._make_adapter()
+        client.configure("api.php", HttpError(500, "error", url="https://wikidata", retryable=True))
+
+        qids = adapter.search_player("Totti")
+        assert qids == []
+
+
+# ═══════════════════════════════════════════════════════════════════════════
+# CANDIDATE PLAYER INTEGRATION TESTS
+# ═══════════════════════════════════════════════════════════════════════════
+
+
+class TestCandidateIntegration:
+    """Tests for adapter → CandidatePlayer integration."""
+
+    def _make_candidate(self, source: str = "wikipedia", source_id: str = "Test") -> CandidatePlayer:
+        cid = make_candidate_id(source, source_id)
+        return CandidatePlayer(
+            candidate_id=cid,
+            source=source,
+            source_id=source_id,
+        )
+
+    # ── Successful integration ───────────────────────────────────────────
+
+    def test_populate_from_successful_result(self):
+        candidate = self._make_candidate()
+        result = AdapterResult(
+            source_name="wikipedia",
+            source_id="Francesco Totti",
+            success=True,
+            player_name="Francesco Totti",
+            aliases=["totti", "er pupone"],
+            birth_year=1976,
+            nationality="ITA",
+            position="Attaccante",
+            career=[
+                {"team": "Roma", "start_year": 1993, "end_year": 2017, "apps": 619, "goals": 250},
+                {"team": "Roma Primavera", "start_year": 1992, "end_year": 1993, "apps": 4, "goals": 0},
+            ],
+            source_metadata={"retrieved_at": "2026-09-11T20:00:00Z"},
+            raw_payload={"wikitext": "..."},
+        )
+
+        populate_candidate_from_result(candidate, result)
+
+        assert candidate.status == CandidateState.FETCHED
+        assert candidate.full_name == "Francesco Totti"
+        assert candidate.aliases == ["totti", "er pupone"]
+        assert candidate.birth_year == 1976
+        assert candidate.nationality == "ITA"
+        assert candidate.position == "Attaccante"
+        assert len(candidate.career) == 2
+        assert candidate.raw_data["source_name"] == "wikipedia"
+
+    def test_transition_to_fetched_records_audit(self):
+        candidate = self._make_candidate()
+        result = AdapterResult(
+            source_name="wikipedia",
+            source_id="Test",
+            success=True,
+            player_name="Test Player",
+            career=[
+                {"team": "A", "start_year": 2010, "end_year": 2015},
+                {"team": "B", "start_year": 2015, "end_year": 2020},
+            ],
+        )
+
+        populate_candidate_from_result(candidate, result)
+
+        assert len(candidate.state_history) == 1
+        assert candidate.state_history[0].from_state == CandidateState.DISCOVERED
+        assert candidate.state_history[0].to_state == CandidateState.FETCHED
+        assert "wikipedia" in (candidate.state_history[0].actor or "")
+
+    def test_partial_result_goes_to_review(self):
+        """Missing career (<2 stops) should transition to REVIEW_REQUIRED."""
+        candidate = self._make_candidate()
+        result = AdapterResult(
+            source_name="wikipedia",
+            source_id="Test",
+            success=True,
+            player_name="Partial Player",
+            career=[{"team": "Solo Club", "start_year": 2020, "end_year": 2024}],
+        )
+
+        populate_candidate_from_result(candidate, result)
+
+        # DISCOVERED → REVIEW_REQUIRED is not directly allowed
+        # but DISCOVERED → FETCHED is, then future steps go to REVIEW_REQUIRED
+        # Let's check what actually happened based on the allowed transitions
+        assert candidate.status in (CandidateState.FETCHED, CandidateState.REVIEW_REQUIRED)
+
+    def test_failed_result_records_errors(self):
+        candidate = self._make_candidate()
+        result = AdapterResult(
+            source_name="wikipedia",
+            source_id="Missing",
+            success=False,
+            errors=[
+                AdapterError(
+                    error_type=AdapterErrorType.NOT_FOUND,
+                    message="Page not found",
+                    source_name="wikipedia",
+                    retryable=False,
+                ),
+            ],
+        )
+
+        populate_candidate_from_result(candidate, result)
+
+        # Should NOT transition
+        assert candidate.status == CandidateState.DISCOVERED
+        assert len(candidate.errors) == 1
+        assert candidate.errors[0].error_type == "not_found"
+        assert candidate.last_error is not None
+
+    def test_record_adapter_failure(self):
+        candidate = self._make_candidate()
+        error = AdapterError(
+            error_type=AdapterErrorType.TIMEOUT,
+            message="Timed out after 30s",
+            source_name="wikipedia",
+            details={"url": "https://wiki/api"},
+            retryable=True,
+        )
+
+        record_adapter_failure(candidate, error)
+
+        assert candidate.retry_count == 1
+        assert len(candidate.errors) == 1
+        assert candidate.errors[0].error_type == "timeout"
+        assert candidate.errors[0].retryable is True
+        assert candidate.can_retry() is True
+
+    def test_multiple_failures_increment_retry(self):
+        candidate = self._make_candidate()
+        for _ in range(3):
+            record_adapter_failure(candidate, AdapterError(
+                error_type=AdapterErrorType.TRANSPORT,
+                message="connection reset",
+                source_name="wikipedia",
+                retryable=True,
+            ))
+
+        assert candidate.retry_count == 3
+        assert candidate.can_retry() is False  # max_retries default is 3
+        assert len(candidate.errors) == 3
+
+    def test_non_retryable_error_no_retry_increment(self):
+        candidate = self._make_candidate()
+        record_adapter_failure(candidate, AdapterError(
+            error_type=AdapterErrorType.NOT_FOUND,
+            message="not found",
+            source_name="wikipedia",
+            retryable=False,
+        ))
+
+        # record_error with retryable=False does not increment
+        assert candidate.retry_count == 0
+
+    # ── Raw data preservation ────────────────────────────────────────────
+
+    def test_raw_data_preserved_in_candidate(self):
+        candidate = self._make_candidate()
+        result = AdapterResult(
+            source_name="wikidata",
+            source_id="Q170984",
+            success=True,
+            player_name="Francesco Totti",
+            career=[
+                {"team": "Q2565", "start_year": 1993, "end_year": 2017},
+                {"team": "Q2565", "start_year": 1992, "end_year": 1993},
+            ],
+            raw_payload={"entity": {"id": "Q170984"}},
+            source_metadata={"retrieved_at": "2026-09-11T20:00:00Z"},
+        )
+
+        populate_candidate_from_result(candidate, result)
+
+        assert candidate.raw_data["source_name"] == "wikidata"
+        assert candidate.raw_data["source_id"] == "Q170984"
+        assert "entity" in candidate.raw_data["raw_payload"]
+
+
+# ═══════════════════════════════════════════════════════════════════════════
+# END-TO-END ADAPTER → CANDIDATE FLOW TESTS
+# ═══════════════════════════════════════════════════════════════════════════
+
+
+class TestEndToEndAdapterFlow:
+    """Full adapter → candidate integration with real fixtures."""
+
+    def test_wikipedia_to_candidate(self):
+        """Wikipedia fixture → adapter → candidate player."""
+        wikitext = _load_fixture("wikipedia_wikitext_totti.txt")
+        client = FakeHttpClient()
+        client.configure("api.php", _wiki_api_response(wikitext))
+        adapter = WikipediaAdapter(http_client=client)
+
+        # 1. Create candidate
+        cid = make_candidate_id("wikipedia", "Francesco Totti")
+        candidate = CandidatePlayer(
+            candidate_id=cid,
+            source="wikipedia",
+            source_id="Francesco Totti",
+        )
+        assert candidate.status == CandidateState.DISCOVERED
+
+        # 2. Execute adapter
+        result = adapter.fetch_player("Francesco Totti")
+        assert result.success is True
+
+        # 3. Populate candidate
+        populate_candidate_from_result(candidate, result)
+        assert candidate.status == CandidateState.FETCHED
+        assert candidate.full_name == "Francesco Totti"
+
+    def test_wikidata_to_candidate(self):
+        """Wikidata fixture → adapter → candidate player."""
+        client = FakeHttpClient()
+        client.configure("EntityData", _wikidata_entity_response("wikidata_entity_totti.json"))
+        adapter = WikidataAdapter(http_client=client)
+
+        cid = make_candidate_id("wikidata", "Q170984")
+        candidate = CandidatePlayer(
+            candidate_id=cid,
+            source="wikidata",
+            source_id="Q170984",
+        )
+
+        result = adapter.fetch_player("Q170984")
+        populate_candidate_from_result(candidate, result)
+
+        assert candidate.status == CandidateState.FETCHED
+        assert candidate.full_name == "Francesco Totti"
+        assert candidate.raw_data["source_name"] == "wikidata"
+
+    def test_failed_adapter_leaves_candidate_discovered(self):
+        """Failed fetch leaves candidate in DISCOVERED state."""
+        client = FakeHttpClient()
+        client.configure("api.php", HttpError(500, "Server Error", url="", retryable=True))
+        adapter = WikipediaAdapter(http_client=client)
+
+        cid = make_candidate_id("wikipedia", "Test")
+        candidate = CandidatePlayer(
+            candidate_id=cid,
+            source="wikipedia",
+            source_id="Test",
+        )
+
+        result = adapter.fetch_player("Test")
+        assert result.success is False
+
+        populate_candidate_from_result(candidate, result)
+        assert candidate.status == CandidateState.DISCOVERED
+        assert len(candidate.errors) >= 1
+
+    def test_no_writes_to_players_json(self):
+        """Verify that adapters and integration never touch data/players.json."""
+        players_path = Path(__file__).parent.parent / "data" / "players.json"
+        if players_path.exists():
+            original_mtime = players_path.stat().st_mtime
+        else:
+            original_mtime = None
+
+        # Run a full adapter → candidate flow
+        client = FakeHttpClient()
+        client.configure("api.php", _wiki_api_response(
+            _load_fixture("wikipedia_wikitext_totti.txt")
+        ))
+        adapter = WikipediaAdapter(http_client=client)
+        result = adapter.fetch_player("Totti")
+        cid = make_candidate_id("wikipedia", "Totti")
+        candidate = CandidatePlayer(candidate_id=cid, source="wikipedia", source_id="Totti")
+        populate_candidate_from_result(candidate, result)
+
+        if original_mtime is not None:
+            assert players_path.stat().st_mtime == original_mtime, (
+                "data/players.json was modified during adapter test!"
+            )
+
+    def test_no_real_network_calls(self):
+        """Verify the FakeHttpClient is used — no real URLs are contacted."""
+        client = FakeHttpClient()
+        client.configure("api.php", _wiki_api_response(""))
+        adapter = WikipediaAdapter(http_client=client)
+
+        adapter.fetch_player("Test")
+
+        # All requests went through the fake client
+        assert len(client.requests) >= 1
+        for req_url in client.requests:
+            assert "api.php" in req_url
+
+
+# ═══════════════════════════════════════════════════════════════════════════
+# WIKIPEDIA PARSER UNIT TESTS (adapted from wiki.py tests)
+# ═══════════════════════════════════════════════════════════════════════════
+
+
+class TestWikipediaParserHelpers:
+    """Low-level parser functions from the Wikipedia adapter."""
+
+    def test_strip_markup_removes_refs(self):
+        assert WikipediaAdapter._strip_markup('text<ref name="x">cite</ref>more') == "textmore"
+
+    def test_strip_markup_removes_templates(self):
+        assert WikipediaAdapter._strip_markup("{{Bandiera|ITA}} testo") == "testo"
+
+    def test_strip_markup_resolves_links(self):
+        assert WikipediaAdapter._strip_markup("[[Real Madrid|Real]]") == "Real"
+        assert WikipediaAdapter._strip_markup("[[Barcelona]]") == "Barcelona"
+
+    def test_strip_markup_removes_bold_italic(self):
+        assert WikipediaAdapter._strip_markup("'''bold''' and ''italic''") == "bold and italic"
+
+    def test_strip_markup_calcio_template(self):
+        assert WikipediaAdapter._strip_markup("{{Calcio Roma}}") == "Roma"
+
+    def test_find_template_basic(self):
+        text = "before {{Bio|nome=Test|cognome=Player}} after"
+        body = WikipediaAdapter._find_template(text, "Bio")
+        assert body is not None
+        assert "nome=Test" in body
+
+    def test_find_template_nested(self):
+        text = "{{Sportivo|squadre={{Carriera sportivo|data}}}}"
+        body = WikipediaAdapter._find_template(text, "Sportivo")
+        assert body is not None
+        assert "Carriera sportivo" in body
+
+    def test_find_template_missing(self):
+        assert WikipediaAdapter._find_template("no template here", "Bio") is None
+
+    def test_parse_years_single(self):
+        assert WikipediaAdapter._parse_years("2012") == (2012, 2012)
+
+    def test_parse_years_range(self):
+        assert WikipediaAdapter._parse_years("2010-2015") == (2010, 2015)
+
+    def test_parse_years_ongoing(self):
+        assert WikipediaAdapter._parse_years("2020-") == (2020, None)
+
+    def test_parse_years_invalid(self):
+        assert WikipediaAdapter._parse_years("not a year") is None
+
+    def test_parse_stats_with_goals(self):
+        assert WikipediaAdapter._parse_stats("619 (250)") == (619, 250)
+
+    def test_parse_stats_no_goals(self):
+        assert WikipediaAdapter._parse_stats("100") == (100, None)
+
+    def test_parse_stats_negative_goals(self):
+        apps, goals = WikipediaAdapter._parse_stats("200 (-45)")
+        assert apps == 200
+        assert goals == -45
+
+    def test_parse_stats_empty(self):
+        assert WikipediaAdapter._parse_stats("") == (None, None)


### PR DESCRIPTION
## Summary

Implements the multi-source player-data adapter layer for the Candidate Player ingestion pipeline (#14).

- Defines the \PlayerSourceAdapter\ abstract contract, structured errors (\AdapterError\, \AdapterErrorType\), and normalized result containers (\AdapterResult\, \CareerEntry\) in \services/adapters/base.py\.
- Adds an injectable, testable HTTP client abstraction (\HttpClient\, \UrllibHttpClient\) in \services/adapters/http_client.py\.
- Implements \WikipediaAdapter\ (\services/adapters/wikipedia.py\) encapsulating \it.wikipedia.org\ page fetching, infobox parsing, and structured error handling.
- Implements \WikidataAdapter\ (\services/adapters/wikidata.py\) using Wikidata REST entity JSON endpoints for structured player metadata and career claims.
- Implements Candidate integration glue (\services/adapters/candidate_integration.py\) to populate \CandidatePlayer\ (#54) models, preserve provenance metadata, and record structured failures without touching production datasets.
- Includes network-independent fixtures for Wikipedia wikitext and Wikidata JSON entities.
- Adds 69 deterministic unit and integration tests in \	ests/test_adapters.py\ covering contracts, HTTP behavior, parsing, Candidate integration, and end-to-end flows.

Closes #14