### PR TITLE
feat(data): automated club normalization and career validation service (#26)

### DIFF
--- a/services/candidate_finding.py
+++ b/services/candidate_finding.py
@@ -1,0 +1,109 @@
+"""Structured findings model for Candidate Player normalization and validation.
+
+Defines the finding severity, structured container, and stable code taxonomy
+used to communicate data quality issues, warnings, and blocking errors
+throughout the Candidate Player lifecycle (#26).
+"""
+from __future__ import annotations
+
+import copy
+from dataclasses import dataclass, field
+from enum import Enum
+from typing import Any, Optional
+
+
+class FindingSeverity(str, Enum):
+    """Livelli di severità per i rilievi di normalizzazione e validazione."""
+
+    WARNING = "warning"  # Sospetto o discrepanza non bloccante; il candidato può essere VALIDATED
+    ERROR = "error"      # Errore bloccante o ambiguità critica; richiede revisione umana (REVIEW_REQUIRED)
+
+
+# Codici stabili per i rilievi (usati nei test e nella Review Queue #15)
+class FindingCode:
+    # Player-level codes
+    PLAYER_NAME_EMPTY = "PLAYER_NAME_EMPTY"
+    PLAYER_NAME_MALFORMED = "PLAYER_NAME_MALFORMED"
+    PLAYER_NATIONALITY_MISSING = "PLAYER_NATIONALITY_MISSING"
+    PLAYER_POSITION_MISSING = "PLAYER_POSITION_MISSING"
+    PLAYER_BIRTH_YEAR_IMPLAUSIBLE = "PLAYER_BIRTH_YEAR_IMPLAUSIBLE"
+    PLAYER_ALIAS_MALFORMED = "PLAYER_ALIAS_MALFORMED"
+    PLAYER_ALIAS_AMBIGUOUS = "PLAYER_ALIAS_AMBIGUOUS"
+
+    # Career-level codes
+    CAREER_EMPTY = "CAREER_EMPTY"
+    CAREER_TOO_SHORT = "CAREER_TOO_SHORT"
+    CAREER_ONE_CLUB_MISMATCH = "CAREER_ONE_CLUB_MISMATCH"
+    CAREER_DUPLICATE_STOP = "CAREER_DUPLICATE_STOP"
+    CAREER_INVALID_RANGE = "CAREER_INVALID_RANGE"
+    CAREER_FUTURE_YEAR = "CAREER_FUTURE_YEAR"
+    CAREER_OVERLAP = "CAREER_OVERLAP"
+    CAREER_ORPHAN_LOAN = "CAREER_ORPHAN_LOAN"
+    CAREER_ORDER = "CAREER_ORDER"
+    CAREER_APPS_GOALS_INVALID = "CAREER_APPS_GOALS_INVALID"
+
+    # Club & stop-level codes
+    CLUB_NAME_MISSING = "CLUB_NAME_MISSING"
+    CLUB_NAME_MALFORMED = "CLUB_NAME_MALFORMED"
+    CLUB_UNRESOLVED_QID = "CLUB_UNRESOLVED_QID"
+    CLUB_MISSING_COUNTRY = "CLUB_MISSING_COUNTRY"
+    CLUB_MISSING_LEAGUE = "CLUB_MISSING_LEAGUE"
+    CLUB_COUNTRY_MISMATCH = "CLUB_COUNTRY_MISMATCH"
+    CLUB_AMBIGUOUS_ALIAS = "CLUB_AMBIGUOUS_ALIAS"
+    CLUB_NORMALIZED = "CLUB_NORMALIZED"
+    LEAGUE_NORMALIZED = "LEAGUE_NORMALIZED"
+
+
+@dataclass
+class CandidateFinding:
+    """Rilievo strutturato emesso dai servizi di normalizzazione e validazione.
+
+    Attributes:
+        code: Codice stabile del rilievo (es. CAREER_DUPLICATE_STOP, CLUB_MISSING_LEAGUE).
+        severity: Livello di gravità (WARNING o ERROR).
+        message: Descrizione comprensibile e azionabile del problema.
+        field_path: Percorso del campo interessato (es. 'full_name', 'career[0].start_year').
+        input_value: Valore grezzo o problematico rilevato.
+        context: Dizionario con metadati contestuali (es. conflicting player ID, suggerimenti).
+        requires_review: Indica se questo rilievo forza lo stato in REVIEW_REQUIRED.
+    """
+
+    code: str
+    severity: FindingSeverity
+    message: str
+    field_path: str
+    input_value: Optional[Any] = None
+    context: dict[str, Any] = field(default_factory=dict)
+    requires_review: bool = False
+
+    def __post_init__(self) -> None:
+        if isinstance(self.severity, str):
+            self.severity = FindingSeverity(self.severity)
+        # Di default, ogni errore bloccante richiede revisione umana
+        if self.severity == FindingSeverity.ERROR:
+            self.requires_review = True
+
+    def to_dict(self) -> dict[str, Any]:
+        """Serializza il rilievo in un dizionario compatibile con JSON."""
+        return {
+            "code": self.code,
+            "severity": self.severity.value,
+            "message": self.message,
+            "field_path": self.field_path,
+            "input_value": copy.deepcopy(self.input_value),
+            "context": copy.deepcopy(self.context),
+            "requires_review": self.requires_review,
+        }
+
+    @classmethod
+    def from_dict(cls, data: dict[str, Any]) -> CandidateFinding:
+        """Ricostruisce un CandidateFinding da dizionario."""
+        return cls(
+            code=str(data["code"]),
+            severity=FindingSeverity(data["severity"]),
+            message=str(data["message"]),
+            field_path=str(data["field_path"]),
+            input_value=data.get("input_value"),
+            context=dict(data.get("context", {})),
+            requires_review=bool(data.get("requires_review", False)),
+        )

--- a/services/candidate_normalization.py
+++ b/services/candidate_normalization.py
@@ -114,7 +114,6 @@ CONSOLIDATED_CLUB_ALIASES: dict[str, str] = {
     "galatasaray": "Galatasaray",
     "fenerbahce": "Fenerbahce",
     "sporting lisbona": "Sporting CP",
-    "sporting": "Sporting CP",
     "vitoria guimaraes": "Vitoria Guimaraes",
     "boca": "Boca Juniors",
     "river": "River Plate",
@@ -368,7 +367,7 @@ POSITION_STANDARDIZATION: dict[str, str] = {
     "striker": "Attaccante", "st": "Attaccante", "punta": "Attaccante",
 }
 
-_CANONICAL_INDEX: Optional[dict[str, tuple[str, str, str]]] = None
+_CANONICAL_INDEX: Optional[dict[str, tuple[str, str, Optional[str]]]] = None
 
 
 def _clean_key(text: Optional[str]) -> str:
@@ -388,14 +387,20 @@ def _clean_key(text: Optional[str]) -> str:
     return " ".join(cleaned.split())
 
 
-def get_canonical_club_index() -> dict[str, tuple[str, str, str]]:
-    """Builds an index of norm(team) -> (canonical_team_name, country, league)
-    from data/players.json. Strictly read-only."""
+def get_canonical_club_index() -> dict[str, tuple[str, str, Optional[str]]]:
+    """Builds an index of norm(team) -> (canonical_team_name, country, None)
+    from data/players.json. Strictly read-only.
+
+    Deterministic club identity may be used to backfill country when unambiguous.
+    Historical league is intentionally NOT indexed or backfilled purely from club identity,
+    as clubs change divisions across seasons.
+    """
     global _CANONICAL_INDEX
     if _CANONICAL_INDEX is not None:
         return _CANONICAL_INDEX
 
-    index: dict[str, dict[tuple[str, str, str], int]] = {}
+    index: dict[str, dict[tuple[str, str], int]] = {}
+    country_counts: dict[str, set[str]] = {}
     try:
         if os.path.exists(_PLAYERS_PATH):
             with open(_PLAYERS_PATH, "r", encoding="utf-8") as f:
@@ -404,24 +409,70 @@ def get_canonical_club_index() -> dict[str, tuple[str, str, str]]:
                 for stop in player.get("career", []):
                     team = stop.get("team")
                     country = stop.get("country")
-                    league = stop.get("league")
-                    if team and country and league:
+                    if team and country:
                         key = _clean_key(team)
-                        if key:
+                        if key and key not in AMBIGUOUS_CLUB_ALIASES:
                             counts = index.setdefault(key, {})
-                            entry = (team, country, league)
+                            entry = (team, country)
                             counts[entry] = counts.get(entry, 0) + 1
+                            country_counts.setdefault(key, set()).add(country)
     except Exception:
         pass
 
-    result: dict[str, tuple[str, str, str]] = {}
+    result: dict[str, tuple[str, str, Optional[str]]] = {}
     for key, counts in index.items():
-        # Pick the most frequently used triple
-        best = max(counts.items(), key=lambda item: item[1])[0]
-        result[key] = best
+        # Only index when club identity is unambiguous (single country in dataset)
+        if len(country_counts.get(key, set())) == 1:
+            best_team, best_country = max(counts.items(), key=lambda item: item[1])[0]
+            result[key] = (best_team, best_country, None)
 
     _CANONICAL_INDEX = result
     return _CANONICAL_INDEX
+
+
+def resolve_historical_league_with_temporal_evidence(
+    team: str,
+    country: Optional[str] = None,
+    start_year: Optional[int] = None,
+    end_year: Optional[int] = None,
+) -> Optional[str]:
+    """Extension point for future season-aware league resolution.
+
+    Historical league cannot be inferred purely from club identity without temporal
+    evidence because clubs change divisions across seasons.
+    Returns None until a temporal/season-aware resolver is implemented.
+    """
+    return None
+
+
+def parse_loan_flag(raw: Any) -> Optional[bool]:
+    """Deterministically parses a loan flag value.
+
+    Recognizes:
+    - Booleans: True, False
+    - Integers/Floats: 1 -> True, 0 -> False
+    - Strings: "true", "1" -> True; "false", "0" -> False (case-insensitive, trimmed)
+
+    Unknown or unhandled values return None and MUST NOT silently become True.
+    """
+    if raw is None:
+        return False
+    if isinstance(raw, bool):
+        return raw
+    if isinstance(raw, (int, float)):
+        if raw == 1:
+            return True
+        if raw == 0:
+            return False
+        return None
+    if isinstance(raw, str):
+        cleaned = raw.strip().lower()
+        if cleaned in ("true", "1"):
+            return True
+        if cleaned in ("false", "0"):
+            return False
+        return None
+    return None
 
 
 def strip_wiki_markup(text: str) -> str:
@@ -567,6 +618,7 @@ def normalize_club_name(
                 context={"candidates": candidates},
             )
         )
+        return cleaned, findings
 
     # 1. Exact or normalized lookup in known aliases
     if key in CONSOLIDATED_CLUB_ALIASES:
@@ -652,43 +704,43 @@ def normalize_career_stop(
     raw_league = stop.get("league")
     norm_league = normalize_league_name(raw_league, norm_country)
 
-    # 4. Canonical index backfill for missing country/league on known clubs
+    # 4. Canonical index backfill for missing country on known unambiguous clubs.
+    # Deterministic club identity may be used to backfill country when unambiguous.
+    # NEVER backfill league purely from club identity without temporal evidence.
     if norm_team:
         key = _clean_key(norm_team)
-        canonical_index = get_canonical_club_index()
-        if key in canonical_index:
-            _, cat_country, cat_league = canonical_index[key]
-            if not norm_country and cat_country:
-                norm_country = cat_country
-                findings.append(
-                    CandidateFinding(
-                        code=FindingCode.CLUB_NORMALIZED,
-                        severity=FindingSeverity.WARNING,
-                        message=f"Paese del club '{norm_team}' dedotto dal dataset: '{cat_country}'",
-                        field_path=f"career[{stop_index}].country",
-                        input_value=raw_country,
-                        context={"deduced_country": cat_country},
-                        requires_review=False,
+        if key not in AMBIGUOUS_CLUB_ALIASES:
+            canonical_index = get_canonical_club_index()
+            if key in canonical_index:
+                cat_team, cat_country, _ = canonical_index[key]
+                if not norm_country and cat_country:
+                    norm_country = cat_country
+                    findings.append(
+                        CandidateFinding(
+                            code=FindingCode.CLUB_NORMALIZED,
+                            severity=FindingSeverity.WARNING,
+                            message=f"Paese del club '{norm_team}' dedotto dal dataset: '{cat_country}'",
+                            field_path=f"career[{stop_index}].country",
+                            input_value=raw_country,
+                            context={"deduced_country": cat_country},
+                            requires_review=False,
+                        )
                     )
-                )
-            if not norm_league and cat_league:
-                norm_league = cat_league
-                findings.append(
-                    CandidateFinding(
-                        code=FindingCode.LEAGUE_NORMALIZED,
-                        severity=FindingSeverity.WARNING,
-                        message=f"Campionato del club '{norm_team}' dedotto dal dataset: '{cat_league}'",
-                        field_path=f"career[{stop_index}].league",
-                        input_value=raw_league,
-                        context={"deduced_league": cat_league},
-                        requires_review=False,
-                    )
-                )
+
+    # 5. League inference: NEVER backfill from club identity alone without temporal evidence.
+    # Preserve missing league, or consult season-aware extension point.
+    if not norm_league and norm_team:
+        norm_league = resolve_historical_league_with_temporal_evidence(
+            team=norm_team,
+            country=norm_country,
+            start_year=norm_stop.get("start_year"),
+            end_year=norm_stop.get("end_year"),
+        )
 
     norm_stop["country"] = norm_country
     norm_stop["league"] = norm_league
 
-    # 5. Numeric fields conversion
+    # 6. Numeric fields conversion
     for year_field in ("start_year", "end_year"):
         val = norm_stop.get(year_field)
         if val is not None and not isinstance(val, int):
@@ -706,9 +758,25 @@ def normalize_career_stop(
             except (ValueError, TypeError):
                 pass
 
-    # 6. Loan flag standardization
-    if "loan" in norm_stop:
-        norm_stop["loan"] = bool(norm_stop["loan"])
+    # 7. Safe loan flag standardization
+    raw_loan = norm_stop.get("loan")
+    if "loan" in norm_stop and raw_loan is not None:
+        parsed_loan = parse_loan_flag(raw_loan)
+        if parsed_loan is not None:
+            norm_stop["loan"] = parsed_loan
+        else:
+            # Unknown value: must not silently become True
+            norm_stop["loan"] = False
+            findings.append(
+                CandidateFinding(
+                    code=FindingCode.CAREER_APPS_GOALS_INVALID,
+                    severity=FindingSeverity.WARNING,
+                    message=f"Valore del flag prestito non riconosciuto per '{norm_team}': '{raw_loan}' (impostato a False)",
+                    field_path=f"career[{stop_index}].loan",
+                    input_value=raw_loan,
+                    requires_review=False,
+                )
+            )
     else:
         norm_stop["loan"] = False
 

--- a/services/candidate_normalization.py
+++ b/services/candidate_normalization.py
@@ -1,0 +1,818 @@
+"""Candidate Player Normalization Service.
+
+Deterministic, reusable normalization layer for Candidate Players (#26).
+- Cleans whitespace, Unicode, and punctuation inconsistencies;
+- Resolves known club and league aliases based on repository standards;
+- Preserves unresolved QIDs and ambiguous names without fuzzy guessing;
+- Standardizes nationality, position, and aliases;
+- Enforces canonical career ordering via `order_career`;
+- Guarantees idempotency (multiple runs produce identical results);
+- Integrates with CandidatePlayer lifecycle: transitions FETCHED -> NORMALIZED.
+"""
+from __future__ import annotations
+
+import json
+import os
+import re
+import unicodedata
+from typing import Any, Optional
+
+from services.candidate_finding import CandidateFinding, FindingCode, FindingSeverity
+from services.candidate_player import CandidatePlayer, CandidateState
+from services.career_order import order_career
+
+_BASE_DIR = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
+_PLAYERS_PATH = os.path.join(_BASE_DIR, "data", "players.json")
+
+# Regex to detect raw Wikidata QID tokens (e.g. Q1853, Q201625)
+_QID_REGEX = re.compile(r"^Q\d+$")
+
+# Regex to strip wiki links: [[Target|Label]] -> Label, [[Target]] -> Target
+_WIKI_LINK_REGEX = re.compile(r"\[\[(?:[^|\]]*\|)?([^\]]+)\]\]")
+
+# Regex to strip wiki templates: {{Template|...}} -> empty
+_WIKI_TEMPLATE_REGEX = re.compile(r"\{\{[^}]*\}\}")
+
+# Consolidated known club aliases (mapping normalized string -> canonical dataset team name)
+# Reuses and unifies definitions from scripts/wikipedia/clubs.py and scripts/wikipedia/normalize_batch.py
+CONSOLIDATED_CLUB_ALIASES: dict[str, str] = {
+    "psv": "PSV Eindhoven",
+    "cadice": "Cádiz",
+    "barcellona": "Barcelona",
+    "psg": "Paris Saint-Germain",
+    "manchester utd": "Manchester United",
+    "manchester united fc": "Manchester United",
+    "man utd": "Manchester United",
+    "man united": "Manchester United",
+    "spurs": "Tottenham",
+    "tottenham hotspur": "Tottenham",
+    "monaco fc": "Monaco",
+    "as monaco": "Monaco",
+    "al nasr dubai": "Al-Nasr",
+    "bayern": "Bayern Monaco",
+    "bayern munchen": "Bayern Monaco",
+    "bayern monaco": "Bayern Monaco",
+    "inter milano": "Inter",
+    "internazionale": "Inter",
+    "fc internazionale": "Inter",
+    "milan": "AC Milan",
+    "ac milan": "AC Milan",
+    "verona": "Hellas Verona",
+    "atletico madrid": "Atletico Madrid",
+    "club atletico de madrid": "Atletico Madrid",
+    "atletico": "Atletico Madrid",
+    "siviglia": "Siviglia",
+    "sevilla fc": "Siviglia",
+    "amburgo": "Amburgo",
+    "hsv": "Amburgo",
+    "colonia": "Colonia",
+    "lilla": "Lilla",
+    "lille": "Lilla",
+    "lione": "Lione",
+    "olympique lyonnais": "Lione",
+    "nizza": "Nizza",
+    "marsiglia": "Marsiglia",
+    "olympique de marseille": "Marsiglia",
+    "stoccarda": "Stoccarda",
+    "vfb stuttgart": "Stoccarda",
+    "saragozza": "Zaragoza",
+    "real saragozza": "Zaragoza",
+    "la coruna": "Deportivo La Coruna",
+    "deportivo la coruna": "Deportivo La Coruna",
+    "deportivo": "Deportivo La Coruna",
+    "celta": "Celta Vigo",
+    "celta de vigo": "Celta Vigo",
+    "betis": "Real Betis",
+    "real betis balompie": "Real Betis",
+    "maiorca": "Maiorca",
+    "rcd mallorca": "Maiorca",
+    "salisburgo": "Salisburgo",
+    "red bull salzburg": "Salisburgo",
+    "basilea": "Basilea",
+    "fc basel": "Basilea",
+    "anversa": "Anversa",
+    "royal antwerp": "Anversa",
+    "brugge": "Club Brugge",
+    "club brugge kv": "Club Brugge",
+    "malines": "Mechelen",
+    "stella rossa": "Red Star Belgrade",
+    "dinamo mosca": "Dinamo Mosca",
+    "cska mosca": "CSKA Mosca",
+    "zenit san pietroburgo": "Zenit",
+    "zenit": "Zenit",
+    "shakhtar": "Shakhtar Donetsk",
+    "shakhtar donetsk": "Shakhtar Donetsk",
+    "dinamo kiev": "Dynamo Kyiv",
+    "dynamo kiev": "Dynamo Kyiv",
+    "steaua bucarest": "Steaua Bucarest",
+    "fcsb": "Steaua Bucarest",
+    "dinamo bucarest": "Dinamo Bucarest",
+    "olympiakos": "Olympiacos",
+    "panathinaikos": "Panathinaikos",
+    "aek atene": "AEK Atene",
+    "besiktas": "Besiktas",
+    "galatasaray": "Galatasaray",
+    "fenerbahce": "Fenerbahce",
+    "sporting lisbona": "Sporting CP",
+    "sporting": "Sporting CP",
+    "vitoria guimaraes": "Vitoria Guimaraes",
+    "boca": "Boca Juniors",
+    "river": "River Plate",
+    "velez sarsfield": "Velez Sarsfield",
+    "velez": "Velez Sarsfield",
+    "gremio": "Gremio",
+    "atletico mineiro": "Atletico Mineiro",
+    "atletico paranaense": "Atletico Paranaense",
+    "san paolo": "Sao Paulo",
+    "corinthians": "Corinthians",
+    "los angeles galaxy": "LA Galaxy",
+    "la galaxy": "LA Galaxy",
+    "new york red bulls": "New York Red Bulls",
+    "d c united": "DC United",
+    "dc united": "DC United",
+    "washington d c united": "DC United",
+    # Renames from normalize_batch
+    "leeds": "Leeds United",
+    "leeds united": "Leeds United",
+    "schalke": "Schalke 04",
+    "schalke 04": "Schalke 04",
+    "paok salonicco": "PAOK",
+    "cerezo": "Cerezo Osaka",
+    "vissel": "Vissel Kobe",
+    "newell s": "Newell's Old Boys",
+    "newell s old boys": "Newell's Old Boys",
+    "kuban": "Kuban Krasnodar",
+    "rubin": "Rubin Kazan",
+    "petrolul": "Petrolul Ploiesti",
+    "malmo": "Malmo FF",
+    "darmstadt": "Darmstadt 98",
+    "plymouth": "Plymouth Argyle",
+    "wigan": "Wigan Athletic",
+    "west bromwich": "West Bromwich Albion",
+    "swansea city": "Swansea",
+    "leicester city": "Leicester",
+    "excelsior rotterdam": "Excelsior",
+    "differdange 03": "Differdange",
+    "real oviedo": "Oviedo",
+    "nacional medellin": "Atletico Nacional",
+    "monaco 1860": "1860 Munich",
+    "cf montreal": "Montreal Impact",
+    "dalian professional": "Dalian Yifang",
+    "shanghai greenland": "Shanghai Shenhua",
+    "neftchi baku": "Neftci Baku",
+    "al jaish": "El Jaish",
+    "grampus": "Nagoya Grampus",
+}
+
+# Known ambiguous aliases that should not be automatically resolved without warning
+AMBIGUOUS_CLUB_ALIASES: dict[str, list[str]] = {
+    "sporting": ["Sporting CP", "Sporting Gijón"],
+    "inter": ["Inter", "Inter Miami", "SC Internacional"],
+    "real": ["Real Madrid", "Real Sociedad", "Real Betis", "Real Zaragoza"],
+    "racing": ["Racing Club", "Racing Santander", "Racing de Ferrol"],
+    "nacional": ["Nacional", "Atletico Nacional", "CD Nacional"],
+    "dynamo": ["Dynamo Kyiv", "Dinamo Mosca", "Dinamo Zagreb"],
+    "dinamo": ["Dynamo Kyiv", "Dinamo Mosca", "Dinamo Zagreb", "Dinamo Bucarest"],
+    "united": ["Manchester United", "Newcastle United", "Leeds United", "West Ham United"],
+    "city": ["Manchester City", "Leicester City", "Swansea City"],
+}
+
+# Known League Aliases
+KNOWN_LEAGUE_ALIASES: dict[str, str] = {
+    "fussball bundesliga": "Bundesliga",
+    "fusball bundesliga": "Bundesliga",
+    "zweite bundesliga": "2. Bundesliga",
+    "2 fussball bundesliga": "2. Bundesliga",
+    "2 fusball bundesliga": "2. Bundesliga",
+    "primera division": "La Liga",
+    "primera division de espana": "La Liga",
+    "super league": "Swiss Super League",
+    "super lig": "Super Lig",
+    "premier league inglese": "Premier League",
+    "liga portugal": "Primeira Liga",
+    "primeira liga portoghese": "Primeira Liga",
+    "campionato di calcio uruguaiano": "Uruguayan Primera Division",
+    "primera division argentina": "Liga Profesional",
+    "campeonato brasileiro serie a": "Brasileirao",
+}
+
+# League names disambiguated by country
+LEAGUE_BY_COUNTRY: dict[tuple[str, str], str] = {
+    ("Brasile", "serie a"): "Brasileirao",
+    ("Brasile", "serie b"): "Campeonato Brasileiro Serie B",
+    ("Brasile", "campeonato brasileiro serie a"): "Brasileirao",
+    ("Cile", "la liga"): "Primera Division Cile",
+    ("Cile", "primera division"): "Primera Division Cile",
+    ("Cile", "segunda division"): "Primera B Cile",
+    ("Malta", "premier league"): "Maltese Premier League",
+    ("Austria", "bundesliga"): "Austrian Bundesliga",
+    ("Argentina", "primera division"): "Liga Profesional",
+    ("Argentina", "la liga"): "Liga Profesional",
+    ("Messico", "primera division"): "Liga MX",
+    ("Messico", "primera division de mexico"): "Liga MX",
+    ("Uruguay", "primera division"): "Uruguayan Primera Division",
+    ("Uruguay", "primera division profesional de uruguay"): "Uruguayan Primera Division",
+    ("Uruguay", "segunda division profesional de uruguay"): "Uruguayan Segunda Division",
+    ("Paraguay", "primera division"): "Primera Division Paraguay",
+    ("Paraguay", "division intermedia"): "Division Intermedia Paraguay",
+    ("Perù", "primera division"): "Primera Division Perù",
+    ("Israele", "ligat ha al"): "Israeli Premier League",
+    ("Svizzera", "super league"): "Swiss Super League",
+    ("Armenia", "arajin xowmb"): "Armenian Premier League",
+    ("Cina", "league two"): "China League Two",
+    ("Cina", "league one"): "China League One",
+    ("Bulgaria", "parva liga"): "Bulgarian First League",
+    ("Bulgaria", "a pfg"): "Bulgarian First League",
+    ("Grecia", "souper ligka ellada"): "Super League Greece",
+    ("Russia", "prem er liga"): "Russian Premier League",
+    ("Russia", "pervaja liga"): "Pervaja Liga",
+    ("Ucraina", "prem jer liha"): "Ukrainian Premier League",
+    ("Repubblica Ceca", "1 liga"): "Czech First League",
+    ("Slovacchia", "superliga"): "Slovak First League",
+    ("Slovenia", "1 snl"): "PrvaLiga",
+    ("Croazia", "2 nl"): "Croatian Second League",
+    ("Portogallo", "segunda liga"): "Liga Portugal 2",
+    ("Uruguay", "primera division uruguaya"): "Uruguayan Primera Division",
+    ("Azerbaigian", "premyer liqas"): "Azerbaijan Premier League",
+    ("Brasile", "campionato paulista serie d"): "Campeonato Paulista Serie D",
+    ("Iran", "lega azadegan"): "Azadegan League",
+    ("Lussemburgo", "division nationale"): "Luxembourg National Division",
+    ("Svizzera", "challenge league"): "Swiss Challenge League",
+    ("Svizzera", "promotion league"): "Swiss Promotion League",
+    ("Inghilterra", "efl championship"): "Championship",
+    ("Inghilterra", "northern premier league division one west"): "Northern Premier League",
+    ("Canada", "major league soccer"): "MLS",
+    ("USA", "major league soccer"): "MLS",
+    ("Colombia", "categoria primera b"): "Categoria Primera B",
+    ("Brasile", "serie c brasile"): "Campeonato Brasileiro Serie C",
+    ("Spagna", "segunda federacion"): "Segunda Federacion",
+    ("Italia", "eccellenza lazio"): "Eccellenza",
+    ("Italia", "eccellenza veneto"): "Eccellenza",
+    ("Italia", "promozione toscana"): "Promozione",
+    ("Jugoslavia", "serbian superliga"): "Serbian SuperLiga",
+    ("Jugoslavia", "serbian superliga jugoslavia"): "Serbian SuperLiga",
+}
+
+# Country code mappings (IOC and ISO 3166-1 alpha-3)
+CODE_TO_COUNTRY: dict[str, str] = {
+    "ITA": "Italia", "ESP": "Spagna", "ENG": "Inghilterra", "FRA": "Francia",
+    "GER": "Germania", "DEU": "Germania", "NED": "Olanda", "NLD": "Olanda",
+    "POR": "Portogallo", "PRT": "Portogallo", "BRA": "Brasile", "ARG": "Argentina",
+    "URU": "Uruguay", "URY": "Uruguay", "CHI": "Cile", "CHL": "Cile",
+    "COL": "Colombia", "PAR": "Paraguay", "PRY": "Paraguay", "PER": "Perù",
+    "ECU": "Ecuador", "VEN": "Venezuela", "BOL": "Bolivia", "MEX": "Messico",
+    "USA": "USA", "CAN": "Canada", "CRC": "Costa Rica", "HON": "Honduras",
+    "JAM": "Giamaica", "BEL": "Belgio", "SUI": "Svizzera", "CHE": "Svizzera",
+    "AUT": "Austria", "SWE": "Svezia", "NOR": "Norvegia", "DEN": "Danimarca",
+    "DNK": "Danimarca", "FIN": "Finlandia", "ISL": "Islanda", "IRL": "Irlanda",
+    "NIR": "Irlanda del Nord", "SCO": "Scozia", "WAL": "Galles", "POL": "Polonia",
+    "CZE": "Repubblica Ceca", "SVK": "Slovacchia", "HUN": "Ungheria",
+    "ROU": "Romania", "ROM": "Romania", "BUL": "Bulgaria", "BGR": "Bulgaria",
+    "GRE": "Grecia", "GRC": "Grecia", "TUR": "Turchia", "RUS": "Russia",
+    "UKR": "Ucraina", "BLR": "Bielorussia", "GEO": "Georgia", "SRB": "Serbia",
+    "CRO": "Croazia", "HRV": "Croazia", "SVN": "Slovenia", "BIH": "Bosnia",
+    "MNE": "Montenegro", "MKD": "Macedonia del Nord", "ALB": "Albania",
+    "YUG": "Jugoslavia", "SCG": "Serbia", "LVA": "Lettonia", "LTU": "Lituania",
+    "EST": "Estonia", "MDA": "Moldova", "AZE": "Azerbaigian", "KAZ": "Kazakistan",
+    "UZB": "Uzbekistan", "ARM": "Armenia", "CYP": "Cipro", "MLT": "Malta",
+    "LUX": "Lussemburgo", "ISR": "Israele", "IRN": "Iran", "IRQ": "Iraq",
+    "KSA": "Arabia Saudita", "UAE": "Emirati Arabi Uniti", "QAT": "Qatar",
+    "JPN": "Giappone", "KOR": "Corea del Sud", "CHN": "Cina", "IND": "India",
+    "AUS": "Australia", "NZL": "Nuova Zelanda", "THA": "Thailandia",
+    "IDN": "Indonesia", "MAS": "Malesia", "SGP": "Singapore", "VIE": "Vietnam",
+    "HKG": "Hong Kong", "MAR": "Marocco", "ALG": "Algeria", "DZA": "Algeria",
+    "TUN": "Tunisia", "EGY": "Egitto", "LBY": "Libia", "SEN": "Senegal",
+    "CIV": "Costa d'Avorio", "GHA": "Ghana", "NGA": "Nigeria", "NGR": "Nigeria",
+    "CMR": "Camerun", "MLI": "Mali", "GUI": "Guinea", "TOG": "Togo",
+    "BEN": "Benin", "BFA": "Burkina Faso", "GAB": "Gabon", "COD": "RD Congo",
+    "CGO": "Congo", "ANG": "Angola", "RSA": "Sudafrica", "ZAF": "Sudafrica",
+    "ZAM": "Zambia", "KEN": "Kenya", "LBR": "Liberia", "GAM": "Gambia",
+    "MTN": "Mauritania", "CPV": "Capo Verde", "GNB": "Guinea-Bissau",
+    "SLE": "Sierra Leone", "MOZ": "Mozambico", "GBR": "Inghilterra",
+}
+
+# Country adjectives (Italian and English common forms)
+ADJECTIVE_TO_COUNTRY: dict[str, str] = {
+    "italiano": "Italia", "italian": "Italia", "italy": "Italia",
+    "spagnolo": "Spagna", "spanish": "Spagna", "spain": "Spagna",
+    "inglese": "Inghilterra", "english": "Inghilterra", "england": "Inghilterra",
+    "francese": "Francia", "french": "Francia", "france": "Francia",
+    "tedesco": "Germania", "german": "Germania", "germany": "Germania",
+    "olandese": "Olanda", "dutch": "Olanda", "netherlands": "Olanda",
+    "portoghese": "Portogallo", "portuguese": "Portogallo", "portugal": "Portogallo",
+    "brasiliano": "Brasile", "brazilian": "Brasile", "brazil": "Brasile",
+    "argentino": "Argentina", "argentine": "Argentina",
+    "uruguaiano": "Uruguay", "uruguayan": "Uruguay",
+    "cileno": "Cile", "chilean": "Cile", "chile": "Cile",
+    "colombiano": "Colombia", "colombian": "Colombia",
+    "bulgaro": "Bulgaria", "bulgarian": "Bulgaria",
+    "croato": "Croazia", "croatian": "Croazia", "croatia": "Croazia",
+    "serbo": "Serbia", "serbian": "Serbia",
+    "rumeno": "Romania", "romeno": "Romania", "romanian": "Romania",
+    "greco": "Grecia", "greek": "Grecia", "greece": "Grecia",
+    "turco": "Turchia", "turkish": "Turchia", "turkey": "Turchia",
+    "russo": "Russia", "russian": "Russia",
+    "ucraino": "Ucraina", "ukrainian": "Ucraina", "ukraine": "Ucraina",
+    "polacco": "Polonia", "polish": "Polonia", "poland": "Polonia",
+    "ceco": "Repubblica Ceca", "czech": "Repubblica Ceca",
+    "slovacco": "Slovacchia", "slovak": "Slovacchia", "slovakia": "Slovacchia",
+    "ungherese": "Ungheria", "hungarian": "Ungheria", "hungary": "Ungheria",
+    "svedese": "Svezia", "swedish": "Svezia", "sweden": "Svezia",
+    "norvegese": "Norvegia", "norwegian": "Norvegia", "norway": "Norvegia",
+    "danese": "Danimarca", "danish": "Danimarca", "denmark": "Danimarca",
+    "finlandese": "Finlandia", "finnish": "Finlandia", "finland": "Finlandia",
+    "svizzero": "Svizzera", "swiss": "Svizzera", "switzerland": "Svizzera",
+    "austriaco": "Austria", "austrian": "Austria",
+    "belga": "Belgio", "belgian": "Belgio", "belgium": "Belgio",
+    "irlandese": "Irlanda", "irish": "Irlanda", "ireland": "Irlanda",
+    "scozzese": "Scozia", "scottish": "Scozia", "scotland": "Scozia",
+    "gallese": "Galles", "welsh": "Galles", "wales": "Galles",
+    "nigeriano": "Nigeria", "nigerian": "Nigeria",
+    "ghanese": "Ghana", "ghanaian": "Ghana",
+    "camerunese": "Camerun", "cameroonian": "Camerun", "cameroon": "Camerun",
+    "senegalese": "Senegal",
+    "ivoriano": "Costa d'Avorio", "ivorian": "Costa d'Avorio",
+    "marocchino": "Marocco", "moroccan": "Marocco", "morocco": "Marocco",
+    "algerino": "Algeria", "algerian": "Algeria",
+    "egiziano": "Egitto", "egyptian": "Egitto", "egypt": "Egitto",
+    "giapponese": "Giappone", "japanese": "Giappone", "japan": "Giappone",
+    "sudcoreano": "Corea del Sud", "south korean": "Corea del Sud", "korean": "Corea del Sud",
+    "cinese": "Cina", "chinese": "Cina", "china": "Cina",
+    "australiano": "Australia", "australian": "Australia",
+    "statunitense": "USA", "american": "USA", "united states": "USA",
+    "messicano": "Messico", "mexican": "Messico", "mexico": "Messico",
+    "paraguaiano": "Paraguay", "paraguayan": "Paraguay",
+    "peruviano": "Perù", "peruvian": "Perù", "peru": "Perù",
+    "ecuadoriano": "Ecuador", "ecuadorian": "Ecuador",
+    "sloveno": "Slovenia", "slovenian": "Slovenia",
+    "bosniaco": "Bosnia", "bosnian": "Bosnia",
+    "montenegrino": "Montenegro",
+    "macedone": "Macedonia del Nord", "macedonian": "Macedonia del Nord",
+    "albanese": "Albania", "albanian": "Albania",
+    "georgiano": "Georgia", "georgian": "Georgia",
+    "israeliano": "Israele", "israeli": "Israele", "israel": "Israele",
+    "iraniano": "Iran", "iranian": "Iran",
+    "jugoslavo": "Jugoslavia", "yugoslav": "Jugoslavia",
+}
+
+# Position standardizations into dataset roles
+POSITION_STANDARDIZATION: dict[str, str] = {
+    "portiere": "Portiere", "goalkeeper": "Portiere", "gk": "Portiere",
+    "difensore": "Difensore", "defender": "Difensore", "df": "Difensore",
+    "terzino": "Difensore", "centrale": "Difensore", "cb": "Difensore",
+    "lb": "Difensore", "rb": "Difensore", "full-back": "Difensore",
+    "centrocampista": "Centrocampista", "midfielder": "Centrocampista",
+    "mf": "Centrocampista", "cm": "Centrocampista", "dm": "Centrocampista",
+    "am": "Centrocampista", "ala": "Centrocampista", "winger": "Attaccante",
+    "attaccante": "Attaccante", "forward": "Attaccante", "fw": "Attaccante",
+    "striker": "Attaccante", "st": "Attaccante", "punta": "Attaccante",
+}
+
+_CANONICAL_INDEX: Optional[dict[str, tuple[str, str, str]]] = None
+
+
+def _clean_key(text: Optional[str]) -> str:
+    """Normalize text into lower-case alphanumeric key for dictionary lookup."""
+    if not text:
+        return ""
+    decomposed = unicodedata.normalize("NFKD", str(text))
+    without_accents = "".join(c for c in decomposed if not unicodedata.combining(c))
+    lower = without_accents.lower()
+    # Strip common club affixes that differ between data sources
+    stripped_affixes = re.sub(
+        r"\b(fc|cf|ac|as|ss|ssc|sc|us|usc|afc|cd|club|calcio|football|futbol)\b",
+        " ",
+        lower,
+    )
+    cleaned = re.sub(r"[^a-z0-9]+", " ", stripped_affixes)
+    return " ".join(cleaned.split())
+
+
+def get_canonical_club_index() -> dict[str, tuple[str, str, str]]:
+    """Builds an index of norm(team) -> (canonical_team_name, country, league)
+    from data/players.json. Strictly read-only."""
+    global _CANONICAL_INDEX
+    if _CANONICAL_INDEX is not None:
+        return _CANONICAL_INDEX
+
+    index: dict[str, dict[tuple[str, str, str], int]] = {}
+    try:
+        if os.path.exists(_PLAYERS_PATH):
+            with open(_PLAYERS_PATH, "r", encoding="utf-8") as f:
+                data = json.load(f)
+            for player in data.get("players", []):
+                for stop in player.get("career", []):
+                    team = stop.get("team")
+                    country = stop.get("country")
+                    league = stop.get("league")
+                    if team and country and league:
+                        key = _clean_key(team)
+                        if key:
+                            counts = index.setdefault(key, {})
+                            entry = (team, country, league)
+                            counts[entry] = counts.get(entry, 0) + 1
+    except Exception:
+        pass
+
+    result: dict[str, tuple[str, str, str]] = {}
+    for key, counts in index.items():
+        # Pick the most frequently used triple
+        best = max(counts.items(), key=lambda item: item[1])[0]
+        result[key] = best
+
+    _CANONICAL_INDEX = result
+    return _CANONICAL_INDEX
+
+
+def strip_wiki_markup(text: str) -> str:
+    """Removes templates {{...}} and unpacks [[Target|Label]] into Label."""
+    if not text:
+        return ""
+    s = _WIKI_TEMPLATE_REGEX.sub("", text)
+    s = _WIKI_LINK_REGEX.sub(r"\1", s)
+    return s.strip()
+
+
+def clean_text(text: Optional[str]) -> str:
+    """Normalizes whitespace, smart quotes, dashes, and applies Unicode NFC."""
+    if not text:
+        return ""
+    s = strip_wiki_markup(str(text))
+    # Replace curly quotes and typographic dashes
+    s = s.replace("’", "'").replace("‘", "'").replace("“", '"').replace("”", '"')
+    s = s.replace("–", "-").replace("—", "-")
+    # Unicode NFC normalization
+    s = unicodedata.normalize("NFC", s)
+    # Collapse whitespace
+    s = re.sub(r"\s+", " ", s)
+    return s.strip()
+
+
+def normalize_country(raw: Optional[str]) -> Optional[str]:
+    """Deterministically normalizes a country string or code into canonical Italian name."""
+    if not raw:
+        return None
+    cleaned = clean_text(raw)
+    if not cleaned:
+        return None
+
+    # Check IOC / ISO code
+    upper_code = cleaned.upper()
+    if upper_code in CODE_TO_COUNTRY:
+        return CODE_TO_COUNTRY[upper_code]
+
+    # Check direct lower match or adjective match
+    key = cleaned.lower()
+    if key in ADJECTIVE_TO_COUNTRY:
+        return ADJECTIVE_TO_COUNTRY[key]
+
+    # Words in raw string
+    words = re.findall(r"[a-zàèéìòùA-Z]+", key)
+    for word in words:
+        if word in ADJECTIVE_TO_COUNTRY:
+            return ADJECTIVE_TO_COUNTRY[word]
+
+    # If already capitalized like a country, return clean
+    return cleaned
+
+
+def normalize_position(raw: Optional[str]) -> Optional[str]:
+    """Maps a raw position string to standard Italian role."""
+    if not raw:
+        return None
+    cleaned = clean_text(raw)
+    if not cleaned:
+        return None
+    key = cleaned.lower().strip()
+    return POSITION_STANDARDIZATION.get(key, cleaned)
+
+
+def normalize_league_name(league: Optional[str], country: Optional[str] = None) -> Optional[str]:
+    """Normalizes league names using repository conventions."""
+    if not league:
+        return None
+    cleaned = clean_text(league)
+    if not cleaned:
+        return None
+
+    key = _clean_key(cleaned)
+    # Check country-specific rule
+    if country:
+        by_country = LEAGUE_BY_COUNTRY.get((country, key))
+        if by_country:
+            return by_country
+
+    if key in KNOWN_LEAGUE_ALIASES:
+        return KNOWN_LEAGUE_ALIASES[key]
+
+    if country == "Svizzera" and key == "super league":
+        return "Swiss Super League"
+
+    return cleaned
+
+
+def normalize_club_name(
+    raw_team: Optional[str],
+    raw_country: Optional[str] = None,
+) -> tuple[str, list[CandidateFinding]]:
+    """Deterministically normalizes a club name without fuzzy guessing.
+
+    Returns:
+        (normalized_team_name, findings_list)
+    """
+    findings: list[CandidateFinding] = []
+    if not raw_team or not str(raw_team).strip():
+        findings.append(
+            CandidateFinding(
+                code=FindingCode.CLUB_NAME_MISSING,
+                severity=FindingSeverity.ERROR,
+                message="Nome del club mancante o vuoto",
+                field_path="team",
+                input_value=raw_team,
+            )
+        )
+        return "", findings
+
+    cleaned = clean_text(raw_team)
+
+    # Check for raw Wikidata QID
+    if _QID_REGEX.match(cleaned):
+        findings.append(
+            CandidateFinding(
+                code=FindingCode.CLUB_UNRESOLVED_QID,
+                severity=FindingSeverity.ERROR,
+                message=f"Il club '{cleaned}' è un identificativo Wikidata QID non risolto",
+                field_path="team",
+                input_value=cleaned,
+                context={"qid": cleaned},
+            )
+        )
+        return cleaned, findings
+
+    key = _clean_key(cleaned)
+
+    # Check ambiguous alias
+    if key in AMBIGUOUS_CLUB_ALIASES:
+        candidates = AMBIGUOUS_CLUB_ALIASES[key]
+        findings.append(
+            CandidateFinding(
+                code=FindingCode.CLUB_AMBIGUOUS_ALIAS,
+                severity=FindingSeverity.WARNING,
+                message=(
+                    f"Il nome del club '{cleaned}' corrisponde a un alias ambiguo tra: "
+                    f"{', '.join(candidates)}"
+                ),
+                field_path="team",
+                input_value=cleaned,
+                context={"candidates": candidates},
+            )
+        )
+
+    # 1. Exact or normalized lookup in known aliases
+    if key in CONSOLIDATED_CLUB_ALIASES:
+        canonical = CONSOLIDATED_CLUB_ALIASES[key]
+        if canonical != cleaned:
+            findings.append(
+                CandidateFinding(
+                    code=FindingCode.CLUB_NORMALIZED,
+                    severity=FindingSeverity.WARNING,
+                    message=f"Club '{cleaned}' normalizzato nel canonico '{canonical}'",
+                    field_path="team",
+                    input_value=cleaned,
+                    context={"original": cleaned, "normalized": canonical},
+                    requires_review=False,
+                )
+            )
+            return canonical, findings
+        return cleaned, findings
+
+    # 2. Lookup in canonical dataset index
+    canonical_index = get_canonical_club_index()
+    if key in canonical_index:
+        canonical_team, _, _ = canonical_index[key]
+        if canonical_team != cleaned:
+            findings.append(
+                CandidateFinding(
+                    code=FindingCode.CLUB_NORMALIZED,
+                    severity=FindingSeverity.WARNING,
+                    message=f"Club '{cleaned}' allineato al nome dataset '{canonical_team}'",
+                    field_path="team",
+                    input_value=cleaned,
+                    context={"original": cleaned, "normalized": canonical_team},
+                    requires_review=False,
+                )
+            )
+            return canonical_team, findings
+
+    # 3. Unfamiliar club: KEEP ORIGINAL CLEANED (do NOT fuzzy guess!)
+    return cleaned, findings
+
+
+def normalize_aliases(aliases: list[str], full_name: Optional[str] = None) -> list[str]:
+    """Normalizes player aliases: lowercase, trimmed, deduplicated in stable order."""
+    res: list[str] = []
+    seen: set[str] = set()
+
+    for a in aliases or []:
+        cleaned = clean_text(a).lower()
+        if cleaned and cleaned not in seen:
+            seen.add(cleaned)
+            res.append(cleaned)
+
+    if full_name:
+        fn_clean = clean_text(full_name).lower()
+        if fn_clean and fn_clean not in seen:
+            seen.add(fn_clean)
+            res.append(fn_clean)
+
+    return res
+
+
+def normalize_career_stop(
+    stop: dict[str, Any],
+    stop_index: int,
+) -> tuple[dict[str, Any], list[CandidateFinding]]:
+    """Normalizes a single career stop and returns (normalized_stop, findings)."""
+    findings: list[CandidateFinding] = []
+    norm_stop = dict(stop)
+
+    # 1. Team normalization
+    raw_team = stop.get("team")
+    norm_team, team_findings = normalize_club_name(raw_team, stop.get("country"))
+    for f in team_findings:
+        f.field_path = f"career[{stop_index}].{f.field_path}"
+        findings.append(f)
+    norm_stop["team"] = norm_team
+
+    # 2. Country normalization
+    raw_country = stop.get("country")
+    norm_country = normalize_country(raw_country)
+
+    # 3. League normalization
+    raw_league = stop.get("league")
+    norm_league = normalize_league_name(raw_league, norm_country)
+
+    # 4. Canonical index backfill for missing country/league on known clubs
+    if norm_team:
+        key = _clean_key(norm_team)
+        canonical_index = get_canonical_club_index()
+        if key in canonical_index:
+            _, cat_country, cat_league = canonical_index[key]
+            if not norm_country and cat_country:
+                norm_country = cat_country
+                findings.append(
+                    CandidateFinding(
+                        code=FindingCode.CLUB_NORMALIZED,
+                        severity=FindingSeverity.WARNING,
+                        message=f"Paese del club '{norm_team}' dedotto dal dataset: '{cat_country}'",
+                        field_path=f"career[{stop_index}].country",
+                        input_value=raw_country,
+                        context={"deduced_country": cat_country},
+                        requires_review=False,
+                    )
+                )
+            if not norm_league and cat_league:
+                norm_league = cat_league
+                findings.append(
+                    CandidateFinding(
+                        code=FindingCode.LEAGUE_NORMALIZED,
+                        severity=FindingSeverity.WARNING,
+                        message=f"Campionato del club '{norm_team}' dedotto dal dataset: '{cat_league}'",
+                        field_path=f"career[{stop_index}].league",
+                        input_value=raw_league,
+                        context={"deduced_league": cat_league},
+                        requires_review=False,
+                    )
+                )
+
+    norm_stop["country"] = norm_country
+    norm_stop["league"] = norm_league
+
+    # 5. Numeric fields conversion
+    for year_field in ("start_year", "end_year"):
+        val = norm_stop.get(year_field)
+        if val is not None and not isinstance(val, int):
+            try:
+                norm_stop[year_field] = int(str(val).strip())
+            except (ValueError, TypeError):
+                # Keep raw for validator to detect
+                pass
+
+    for stat_field in ("apps", "goals"):
+        val = norm_stop.get(stat_field)
+        if val is not None and not isinstance(val, int):
+            try:
+                norm_stop[stat_field] = int(str(val).strip())
+            except (ValueError, TypeError):
+                pass
+
+    # 6. Loan flag standardization
+    if "loan" in norm_stop:
+        norm_stop["loan"] = bool(norm_stop["loan"])
+    else:
+        norm_stop["loan"] = False
+
+    return norm_stop, findings
+
+
+def normalize_candidate(
+    candidate: CandidatePlayer,
+    actor: str = "service:normalization",
+) -> CandidatePlayer:
+    """Applies deterministic normalization to a CandidatePlayer.
+
+    - Cleans full_name, aliases, nationality, position;
+    - Normalizes career stops and canonicalizes ordering via `order_career`;
+    - Appends structured findings to `candidate.metadata['normalization_findings']`;
+    - Appends warning strings to `candidate.validation_warnings` without duplicating;
+    - Transitions FETCHED -> NORMALIZED (or remains NORMALIZED if already NORMALIZED).
+    - Idempotent: multiple calls produce identical results.
+
+    Args:
+        candidate: CandidatePlayer to normalize.
+        actor: System/service identifier for audit trail.
+
+    Returns:
+        The normalized CandidatePlayer (mutated in-place).
+    """
+    all_findings: list[CandidateFinding] = []
+
+    # 1. Full name
+    raw_name = candidate.full_name
+    if raw_name:
+        cleaned_name = clean_text(raw_name)
+        if _QID_REGEX.match(cleaned_name):
+            all_findings.append(
+                CandidateFinding(
+                    code=FindingCode.PLAYER_NAME_MALFORMED,
+                    severity=FindingSeverity.ERROR,
+                    message=f"Il nome del giocatore '{cleaned_name}' è un QID Wikidata non risolto",
+                    field_path="full_name",
+                    input_value=cleaned_name,
+                )
+            )
+        candidate.full_name = cleaned_name
+    else:
+        all_findings.append(
+            CandidateFinding(
+                code=FindingCode.PLAYER_NAME_EMPTY,
+                severity=FindingSeverity.ERROR,
+                message="Il nome completo del giocatore è vuoto",
+                field_path="full_name",
+                input_value=raw_name,
+            )
+        )
+
+    # 2. Nationality
+    candidate.nationality = normalize_country(candidate.nationality)
+
+    # 3. Position
+    candidate.position = normalize_position(candidate.position)
+
+    # 4. Aliases
+    candidate.aliases = normalize_aliases(candidate.aliases, candidate.full_name)
+
+    # 5. Career stops normalization
+    normalized_stops: list[dict[str, Any]] = []
+    for idx, stop in enumerate(candidate.career or []):
+        norm_stop, stop_findings = normalize_career_stop(stop, idx)
+        normalized_stops.append(norm_stop)
+        all_findings.extend(stop_findings)
+
+    # 6. Career ordering via order_career
+    ordered_stops = order_career(normalized_stops)
+    if ordered_stops != normalized_stops:
+        all_findings.append(
+            CandidateFinding(
+                code=FindingCode.CAREER_ORDER,
+                severity=FindingSeverity.WARNING,
+                message="L'ordine delle tappe di carriera è stato allineato alla convenzione canonica",
+                field_path="career",
+                context={"original_len": len(normalized_stops), "ordered_len": len(ordered_stops)},
+                requires_review=False,
+            )
+        )
+    candidate.career = ordered_stops
+
+    # 7. Persist structured normalization findings in metadata
+    norm_findings_dicts = [f.to_dict() for f in all_findings]
+    if all_findings or "normalization_findings" not in candidate.metadata:
+        candidate.metadata["normalization_findings"] = norm_findings_dicts
+
+    # Merge warning messages into candidate.validation_warnings (deduplicated)
+    existing_warnings = set(candidate.validation_warnings)
+    for f in all_findings:
+        if f.severity == FindingSeverity.WARNING and f.message not in existing_warnings:
+            candidate.validation_warnings.append(f.message)
+            existing_warnings.add(f.message)
+
+    # 8. Transition state FETCHED -> NORMALIZED
+    if candidate.status == CandidateState.FETCHED and candidate.can_transition_to(CandidateState.NORMALIZED):
+        candidate.transition_to(
+            CandidateState.NORMALIZED,
+            reason="Normalizzazione deterministica completata",
+            actor=actor,
+            metadata={"findings_count": len(all_findings)},
+        )
+
+    return candidate

--- a/services/candidate_validation.py
+++ b/services/candidate_validation.py
@@ -23,6 +23,7 @@ from services.candidate_normalization import (
     clean_text,
     get_canonical_club_index,
     normalize_candidate,
+    parse_loan_flag,
 )
 from services.candidate_player import CandidatePlayer, CandidateState
 from services.career_order import order_career
@@ -302,7 +303,9 @@ def validate_candidate_data(
         league = stop.get("league")
         start_year = stop.get("start_year")
         end_year = stop.get("end_year")
-        loan = bool(stop.get("loan", False))
+        raw_loan = stop.get("loan", False)
+        parsed_loan = parse_loan_flag(raw_loan)
+        loan = parsed_loan if parsed_loan is not None else False
         apps = stop.get("apps")
         goals = stop.get("goals")
 
@@ -509,6 +512,19 @@ def validate_candidate_data(
                             input_value=stat_val,
                         )
                     )
+
+        # Loan validity check
+        if "loan" in stop and stop["loan"] is not None and not isinstance(stop["loan"], bool):
+            if parse_loan_flag(stop["loan"]) is None:
+                findings.append(
+                    CandidateFinding(
+                        code=FindingCode.CAREER_APPS_GOALS_INVALID,
+                        severity=FindingSeverity.ERROR,
+                        message=f"Valore 'loan' non valido ({stop['loan']}) per '{team}': atteso booleano true/false",
+                        field_path=f"career[{idx}].loan",
+                        input_value=stop["loan"],
+                    )
+                )
 
         # Duplicate stop detection
         if team and isinstance(start_year, int):

--- a/services/candidate_validation.py
+++ b/services/candidate_validation.py
@@ -1,0 +1,750 @@
+"""Candidate Player Validation Service.
+
+Deterministic, reusable validation engine for Candidate Players (#26).
+- Detects empty/short careers, invalid ranges, future dates, and corrupt data;
+- Differentiates legitimate transfers/loans from impossible contract overlaps;
+- Flags unresolved QIDs, missing countries/leagues, and ambiguous aliases;
+- Uses an injectable current year provider to remain resilient across years;
+- Integrates with the Candidate Player lifecycle:
+  NORMALIZED -> VALIDATED (if zero ERROR findings)
+  NORMALIZED -> REVIEW_REQUIRED (if at least one ERROR finding);
+- Never touches or modifies data/players.json.
+"""
+from __future__ import annotations
+
+import json
+import os
+import re
+from datetime import datetime, timezone
+from typing import Callable, Optional
+
+from services.candidate_finding import CandidateFinding, FindingCode, FindingSeverity
+from services.candidate_normalization import (
+    clean_text,
+    get_canonical_club_index,
+    normalize_candidate,
+)
+from services.candidate_player import CandidatePlayer, CandidateState
+from services.career_order import order_career
+
+_BASE_DIR = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
+_PLAYERS_PATH = os.path.join(_BASE_DIR, "data", "players.json")
+_CONFIG_PATH = os.path.join(_BASE_DIR, "data", "config.json")
+
+_QID_REGEX = re.compile(r"^Q\d+$")
+_MIN_PLAUSIBLE_YEAR = 1890
+
+_EXISTING_ALIASES_CACHE: Optional[dict[str, dict[str, str]]] = None
+_MULTI_COUNTRY_CLUBS_CACHE: Optional[set[str]] = None
+
+
+def get_default_current_year() -> int:
+    """Returns the current UTC year."""
+    return datetime.now(timezone.utc).year
+
+
+def _load_production_alias_index() -> dict[str, dict[str, str]]:
+    """Builds a read-only index of lowercase alias -> {'id': pid, 'full_name': name} from data/players.json."""
+    global _EXISTING_ALIASES_CACHE
+    if _EXISTING_ALIASES_CACHE is not None:
+        return _EXISTING_ALIASES_CACHE
+
+    alias_map: dict[str, dict[str, str]] = {}
+    try:
+        if os.path.exists(_PLAYERS_PATH):
+            with open(_PLAYERS_PATH, "r", encoding="utf-8") as f:
+                data = json.load(f)
+            for p in data.get("players", []):
+                pid = p.get("id", "")
+                pname = p.get("full_name", "")
+                entry = {"id": pid, "full_name": pname}
+                for alias in p.get("aliases", []):
+                    clean_a = clean_text(alias).lower()
+                    if clean_a:
+                        alias_map[clean_a] = entry
+    except Exception:
+        pass
+
+    _EXISTING_ALIASES_CACHE = alias_map
+    return _EXISTING_ALIASES_CACHE
+
+
+def _load_multi_country_clubs() -> set[str]:
+    """Loads allowed multi-country clubs from data/config.json."""
+    global _MULTI_COUNTRY_CLUBS_CACHE
+    if _MULTI_COUNTRY_CLUBS_CACHE is not None:
+        return _MULTI_COUNTRY_CLUBS_CACHE
+
+    allowed = set()
+    try:
+        if os.path.exists(_CONFIG_PATH):
+            with open(_CONFIG_PATH, "r", encoding="utf-8") as f:
+                cfg = json.load(f)
+            allowed = set(cfg.get("multi_country_clubs", {}).keys())
+    except Exception:
+        pass
+
+    _MULTI_COUNTRY_CLUBS_CACHE = allowed
+    return _MULTI_COUNTRY_CLUBS_CACHE
+
+
+def validate_candidate_data(
+    candidate: CandidatePlayer,
+    current_year_provider: Optional[Callable[[], int]] = None,
+) -> list[CandidateFinding]:
+    """Performs comprehensive deterministic validation checks on candidate data.
+
+    Returns a list of structured CandidateFinding objects (WARNING and ERROR).
+    """
+    findings: list[CandidateFinding] = []
+    current_year = current_year_provider() if current_year_provider else get_default_current_year()
+
+    # 1. Player-level checks
+    # Full Name
+    name = candidate.full_name
+    if not name or not str(name).strip():
+        findings.append(
+            CandidateFinding(
+                code=FindingCode.PLAYER_NAME_EMPTY,
+                severity=FindingSeverity.ERROR,
+                message="Il nome completo del giocatore è vuoto o mancante",
+                field_path="full_name",
+                input_value=name,
+            )
+        )
+    else:
+        name_clean = clean_text(name)
+        if _QID_REGEX.match(name_clean):
+            findings.append(
+                CandidateFinding(
+                    code=FindingCode.PLAYER_NAME_MALFORMED,
+                    severity=FindingSeverity.ERROR,
+                    message=f"Il nome '{name_clean}' è un QID Wikidata non risolto",
+                    field_path="full_name",
+                    input_value=name,
+                )
+            )
+        elif len(name_clean) < 2 or len(name_clean) > 80 or any(c in name for c in "{}[]<>"):
+            findings.append(
+                CandidateFinding(
+                    code=FindingCode.PLAYER_NAME_MALFORMED,
+                    severity=FindingSeverity.ERROR,
+                    message=f"Nome del giocatore malformato o con markup residuo: '{name}'",
+                    field_path="full_name",
+                    input_value=name,
+                )
+            )
+
+    # Nationality
+    if not candidate.nationality or not str(candidate.nationality).strip():
+        findings.append(
+            CandidateFinding(
+                code=FindingCode.PLAYER_NATIONALITY_MISSING,
+                severity=FindingSeverity.ERROR,
+                message="Nazionalità del giocatore mancante",
+                field_path="nationality",
+                input_value=candidate.nationality,
+            )
+        )
+
+    # Position
+    if not candidate.position or not str(candidate.position).strip():
+        findings.append(
+            CandidateFinding(
+                code=FindingCode.PLAYER_POSITION_MISSING,
+                severity=FindingSeverity.WARNING,
+                message="Ruolo del giocatore mancante",
+                field_path="position",
+                input_value=candidate.position,
+                requires_review=False,
+            )
+        )
+
+    # Birth Year
+    birth_year = candidate.birth_year
+    if birth_year is not None:
+        if not isinstance(birth_year, int) or isinstance(birth_year, bool):
+            findings.append(
+                CandidateFinding(
+                    code=FindingCode.PLAYER_BIRTH_YEAR_IMPLAUSIBLE,
+                    severity=FindingSeverity.ERROR,
+                    message=f"Anno di nascita non numerico: {birth_year}",
+                    field_path="birth_year",
+                    input_value=birth_year,
+                )
+            )
+        elif birth_year < _MIN_PLAUSIBLE_YEAR:
+            findings.append(
+                CandidateFinding(
+                    code=FindingCode.PLAYER_BIRTH_YEAR_IMPLAUSIBLE,
+                    severity=FindingSeverity.ERROR,
+                    message=f"Anno di nascita implausibile ({birth_year} < {_MIN_PLAUSIBLE_YEAR})",
+                    field_path="birth_year",
+                    input_value=birth_year,
+                )
+            )
+        elif birth_year > current_year:
+            findings.append(
+                CandidateFinding(
+                    code=FindingCode.CAREER_FUTURE_YEAR,
+                    severity=FindingSeverity.ERROR,
+                    message=f"Anno di nascita nel futuro ({birth_year} > {current_year})",
+                    field_path="birth_year",
+                    input_value=birth_year,
+                )
+            )
+
+    # Aliases
+    prod_alias_index = _load_production_alias_index()
+    for idx, alias in enumerate(candidate.aliases or []):
+        alias_clean = clean_text(alias).lower()
+        if _QID_REGEX.match(alias_clean):
+            findings.append(
+                CandidateFinding(
+                    code=FindingCode.PLAYER_ALIAS_MALFORMED,
+                    severity=FindingSeverity.WARNING,
+                    message=f"L'alias '{alias}' è un QID Wikidata non risolto",
+                    field_path=f"aliases[{idx}]",
+                    input_value=alias,
+                    requires_review=False,
+                )
+            )
+        # Check collision with existing players in production dataset
+        existing_owner = prod_alias_index.get(alias_clean)
+        if existing_owner:
+            owner_id = existing_owner["id"]
+            owner_name = existing_owner["full_name"]
+            cand_name = candidate.full_name or ""
+            is_same = False
+            if cand_name:
+                cand_clean = clean_text(cand_name).lower()
+                owner_clean = clean_text(owner_name).lower()
+                if cand_clean == owner_clean:
+                    is_same = True
+                else:
+                    from services.candidate_player import _clean_slug
+                    if _clean_slug(cand_name) == owner_id or _clean_slug(cand_name) == _clean_slug(owner_name):
+                        is_same = True
+
+            if not is_same:
+                findings.append(
+                    CandidateFinding(
+                        code=FindingCode.PLAYER_ALIAS_AMBIGUOUS,
+                        severity=FindingSeverity.ERROR,
+                        message=f"L'alias '{alias}' è già assegnato al diverso giocatore di produzione '{owner_name}' ({owner_id})",
+                        field_path=f"aliases[{idx}]",
+                        input_value=alias,
+                        context={"conflicting_player_id": owner_id, "conflicting_player_name": owner_name},
+                    )
+                )
+
+    # 2. Career-level checks
+    career = candidate.career or []
+    one_club = bool(candidate.metadata.get("one_club_career", False))
+
+    if len(career) == 0:
+        findings.append(
+            CandidateFinding(
+                code=FindingCode.CAREER_EMPTY,
+                severity=FindingSeverity.ERROR,
+                message="Carriera vuota: nessuna tappa registrata",
+                field_path="career",
+                input_value=[],
+            )
+        )
+        return findings
+
+    if len(career) == 1 and not one_club:
+        findings.append(
+            CandidateFinding(
+                code=FindingCode.CAREER_TOO_SHORT,
+                severity=FindingSeverity.ERROR,
+                message=(
+                    "Carriera di un solo club senza flag 'one_club_career': "
+                    "verificare se si tratta di una bandiera o di dati incompleti"
+                ),
+                field_path="career",
+                context={"career_len": 1},
+            )
+        )
+    elif len(career) > 1 and one_club:
+        findings.append(
+            CandidateFinding(
+                code=FindingCode.CAREER_ONE_CLUB_MISMATCH,
+                severity=FindingSeverity.ERROR,
+                message="Flag 'one_club_career' presente ma la carriera ha più di una tappa",
+                field_path="career",
+                context={"career_len": len(career)},
+            )
+        )
+
+    # Check career ordering
+    canonical_order = order_career(career)
+    if canonical_order != career:
+        findings.append(
+            CandidateFinding(
+                code=FindingCode.CAREER_ORDER,
+                severity=FindingSeverity.ERROR,
+                message="Le tappe di carriera non sono nel corretto ordine canonico",
+                field_path="career",
+            )
+        )
+
+    # 3. Stop-level checks
+    canonical_clubs = get_canonical_club_index()
+    multi_country = _load_multi_country_clubs()
+
+    seen_exact_stops: set[tuple[str, Optional[int], Optional[int], bool]] = set()
+
+    for idx, stop in enumerate(career):
+        team = stop.get("team")
+        country = stop.get("country")
+        league = stop.get("league")
+        start_year = stop.get("start_year")
+        end_year = stop.get("end_year")
+        loan = bool(stop.get("loan", False))
+        apps = stop.get("apps")
+        goals = stop.get("goals")
+
+        # Team name
+        if not team or not str(team).strip():
+            findings.append(
+                CandidateFinding(
+                    code=FindingCode.CLUB_NAME_MISSING,
+                    severity=FindingSeverity.ERROR,
+                    message="Nome del club mancante nella tappa",
+                    field_path=f"career[{idx}].team",
+                    input_value=team,
+                )
+            )
+        else:
+            clean_team = clean_text(str(team))
+            if _QID_REGEX.match(clean_team):
+                findings.append(
+                    CandidateFinding(
+                        code=FindingCode.CLUB_UNRESOLVED_QID,
+                        severity=FindingSeverity.ERROR,
+                        message=f"Il club '{clean_team}' è un QID Wikidata non risolto",
+                        field_path=f"career[{idx}].team",
+                        input_value=team,
+                    )
+                )
+            elif any(c in str(team) for c in "{}[]<>"):
+                findings.append(
+                    CandidateFinding(
+                        code=FindingCode.CLUB_NAME_MALFORMED,
+                        severity=FindingSeverity.ERROR,
+                        message=f"Nome del club con markup o caratteri non ammessi: '{team}'",
+                        field_path=f"career[{idx}].team",
+                        input_value=team,
+                    )
+                )
+
+        # Missing country
+        if not country or not str(country).strip() or country == "?":
+            findings.append(
+                CandidateFinding(
+                    code=FindingCode.CLUB_MISSING_COUNTRY,
+                    severity=FindingSeverity.ERROR,
+                    message=f"Paese mancante per il club '{team}'",
+                    field_path=f"career[{idx}].country",
+                    input_value=country,
+                )
+            )
+
+        # Missing league
+        if not league or not str(league).strip() or league == "?":
+            findings.append(
+                CandidateFinding(
+                    code=FindingCode.CLUB_MISSING_LEAGUE,
+                    severity=FindingSeverity.ERROR,
+                    message=f"Campionato mancante per il club '{team}'",
+                    field_path=f"career[{idx}].league",
+                    input_value=league,
+                )
+            )
+
+        # Multi-country mismatch
+        if team and country and team not in multi_country:
+            team_lower = clean_text(team).lower()
+            # If club exists in canonical index with another country
+            for _, (can_team, can_country, _) in canonical_clubs.items():
+                if can_team.lower() == team_lower and can_country != country:
+                    findings.append(
+                        CandidateFinding(
+                            code=FindingCode.CLUB_COUNTRY_MISMATCH,
+                            severity=FindingSeverity.WARNING,
+                            message=(
+                                f"Il club '{team}' è associato a '{country}', mentre nel dataset è '{can_country}'"
+                            ),
+                            field_path=f"career[{idx}].country",
+                            input_value=country,
+                            context={"expected_country": can_country},
+                            requires_review=False,
+                        )
+                    )
+                    break
+
+        # Start year checks
+        if start_year is None:
+            findings.append(
+                CandidateFinding(
+                    code=FindingCode.CAREER_INVALID_RANGE,
+                    severity=FindingSeverity.ERROR,
+                    message=f"Anno di inizio mancante per la tappa '{team}'",
+                    field_path=f"career[{idx}].start_year",
+                    input_value=start_year,
+                )
+            )
+        elif not isinstance(start_year, int) or isinstance(start_year, bool):
+            findings.append(
+                CandidateFinding(
+                    code=FindingCode.CAREER_INVALID_RANGE,
+                    severity=FindingSeverity.ERROR,
+                    message=f"Anno di inizio non numerico per la tappa '{team}': {start_year}",
+                    field_path=f"career[{idx}].start_year",
+                    input_value=start_year,
+                )
+            )
+        else:
+            if start_year < _MIN_PLAUSIBLE_YEAR:
+                findings.append(
+                    CandidateFinding(
+                        code=FindingCode.CAREER_INVALID_RANGE,
+                        severity=FindingSeverity.ERROR,
+                        message=f"Anno di inizio implausibile per la tappa '{team}': {start_year}",
+                        field_path=f"career[{idx}].start_year",
+                        input_value=start_year,
+                    )
+                )
+            elif start_year > current_year:
+                findings.append(
+                    CandidateFinding(
+                        code=FindingCode.CAREER_FUTURE_YEAR,
+                        severity=FindingSeverity.ERROR,
+                        message=f"Anno di inizio nel futuro ({start_year} > {current_year}) per '{team}'",
+                        field_path=f"career[{idx}].start_year",
+                        input_value=start_year,
+                    )
+                )
+
+            if birth_year is not None and isinstance(birth_year, int) and (start_year - birth_year < 14):
+                findings.append(
+                    CandidateFinding(
+                        code=FindingCode.CAREER_INVALID_RANGE,
+                        severity=FindingSeverity.ERROR,
+                        message=(
+                            f"Inizio carriera ({start_year}) incompatibile con la nascita ({birth_year}): "
+                            f"meno di 14 anni ({start_year - birth_year})"
+                        ),
+                        field_path=f"career[{idx}].start_year",
+                        input_value=start_year,
+                        context={"birth_year": birth_year, "age_at_start": start_year - birth_year},
+                    )
+                )
+
+        # End year checks
+        if end_year is not None:
+            if not isinstance(end_year, int) or isinstance(end_year, bool):
+                findings.append(
+                    CandidateFinding(
+                        code=FindingCode.CAREER_INVALID_RANGE,
+                        severity=FindingSeverity.ERROR,
+                        message=f"Anno di fine non numerico per '{team}': {end_year}",
+                        field_path=f"career[{idx}].end_year",
+                        input_value=end_year,
+                    )
+                )
+            else:
+                if isinstance(start_year, int) and end_year < start_year:
+                    findings.append(
+                        CandidateFinding(
+                            code=FindingCode.CAREER_INVALID_RANGE,
+                            severity=FindingSeverity.ERROR,
+                            message=f"Anno di fine ({end_year}) precedente all'inizio ({start_year}) per '{team}'",
+                            field_path=f"career[{idx}].end_year",
+                            input_value=end_year,
+                        )
+                    )
+                elif end_year > current_year:
+                    findings.append(
+                        CandidateFinding(
+                            code=FindingCode.CAREER_FUTURE_YEAR,
+                            severity=FindingSeverity.ERROR,
+                            message=f"Anno di fine nel futuro ({end_year} > {current_year}) per '{team}'",
+                            field_path=f"career[{idx}].end_year",
+                            input_value=end_year,
+                        )
+                    )
+        else:
+            # end_year is None (ongoing)
+            # Ongoing is valid ONLY if it's the last stop (or among the last concurrent stops)
+            if idx < len(career) - 1:
+                # Check if subsequent stops have a start year after this one
+                later_stops = [s for s in career[idx + 1:] if isinstance(s.get("start_year"), int)]
+                if later_stops and any(s["start_year"] > (start_year or 0) for s in later_stops):
+                    findings.append(
+                        CandidateFinding(
+                            code=FindingCode.CAREER_INVALID_RANGE,
+                            severity=FindingSeverity.ERROR,
+                            message=(
+                                f"Tappa '{team}' senza anno di fine (in corso) posizionata prima "
+                                f"di tappe successive"
+                            ),
+                            field_path=f"career[{idx}].end_year",
+                            input_value=None,
+                        )
+                    )
+
+        # Apps & Goals
+        for stat_name, stat_val in (("apps", apps), ("goals", goals)):
+            if stat_val is not None:
+                if not isinstance(stat_val, int) or isinstance(stat_val, bool) or stat_val < 0:
+                    findings.append(
+                        CandidateFinding(
+                            code=FindingCode.CAREER_APPS_GOALS_INVALID,
+                            severity=FindingSeverity.ERROR,
+                            message=f"Valore '{stat_name}' non valido ({stat_val}) per '{team}': atteso intero >= 0",
+                            field_path=f"career[{idx}].{stat_name}",
+                            input_value=stat_val,
+                        )
+                    )
+
+        # Duplicate stop detection
+        if team and isinstance(start_year, int):
+            stop_sig = (clean_text(str(team)).lower(), start_year, end_year, loan)
+            if stop_sig in seen_exact_stops:
+                findings.append(
+                    CandidateFinding(
+                        code=FindingCode.CAREER_DUPLICATE_STOP,
+                        severity=FindingSeverity.ERROR,
+                        message=f"Tappa duplicata rilevata per '{team}' ({start_year}-{end_year or 'oggi'})",
+                        field_path=f"career[{idx}]",
+                        context={"team": team, "start_year": start_year, "end_year": end_year},
+                    )
+                )
+            else:
+                seen_exact_stops.add(stop_sig)
+
+    # 4. Overlap analysis across stops
+    # Distinguish:
+    # - Legitimate loan within parent contract -> VALID
+    # - Same-year transfer (A.end == B.start) -> VALID
+    # - Multiple clubs in same season/year -> VALID
+    # - Impossible/suspicious multi-year overlap between permanent contracts -> ERROR
+    # - Loan without parent contract -> WARNING (CAREER_ORPHAN_LOAN)
+    permanent_stops = [
+        (i, s) for i, s in enumerate(career)
+        if not s.get("loan") and isinstance(s.get("start_year"), int)
+    ]
+
+    for i in range(len(permanent_stops)):
+        idx_a, stop_a = permanent_stops[i]
+        start_a = stop_a["start_year"]
+        end_a = stop_a.get("end_year")
+        team_a = stop_a.get("team")
+
+        for j in range(i + 1, len(permanent_stops)):
+            idx_b, stop_b = permanent_stops[j]
+            start_b = stop_b["start_year"]
+            end_b = stop_b.get("end_year")
+            team_b = stop_b.get("team")
+
+            if clean_text(str(team_a)).lower() == clean_text(str(team_b)).lower():
+                # Same club: if disjoint periods, return to club is VALID.
+                # If overlapping, duplicate/overlap error.
+                if end_a is None or (isinstance(end_a, int) and start_b < end_a):
+                    findings.append(
+                        CandidateFinding(
+                            code=FindingCode.CAREER_OVERLAP,
+                            severity=FindingSeverity.ERROR,
+                            message=f"Periodi sovrapposti per lo stesso club '{team_a}'",
+                            field_path=f"career[{idx_b}]",
+                            context={"first_stop": idx_a, "second_stop": idx_b},
+                        )
+                    )
+                continue
+
+            # Different permanent clubs:
+            # Overlap occurs if stop_b starts before stop_a ends.
+            # However: in football, same-year transfer (start_b == end_a) is VALID.
+            # Suspicious/impossible overlap is when start_b < end_a (by 1 or more years)
+            # or if stop_a has end_year=None (ongoing) while stop_b starts later.
+            if end_a is None:
+                findings.append(
+                    CandidateFinding(
+                        code=FindingCode.CAREER_OVERLAP,
+                        severity=FindingSeverity.ERROR,
+                        message=(
+                            f"Contratto in corso con '{team_a}' si sovrappone al contratto "
+                            f"con '{team_b}' ({start_b})"
+                        ),
+                        field_path=f"career[{idx_b}]",
+                        context={"first_stop": idx_a, "second_stop": idx_b},
+                    )
+                )
+            elif isinstance(end_a, int) and start_b < end_a:
+                # E.g. A is 2010-2015, B starts in 2012 -> 3 years overlapping permanent contracts
+                overlap_years = end_a - start_b
+                findings.append(
+                    CandidateFinding(
+                        code=FindingCode.CAREER_OVERLAP,
+                        severity=FindingSeverity.ERROR,
+                        message=(
+                            f"Sovrapposizione pluriennale impossibile tra contratti permanenti: "
+                            f"'{team_a}' ({start_a}-{end_a}) e '{team_b}' ({start_b}-{end_b or 'oggi'}) "
+                            f"({overlap_years} anni di sovrapposizione)"
+                        ),
+                        field_path=f"career[{idx_b}]",
+                        context={
+                            "team_a": team_a, "years_a": f"{start_a}-{end_a}",
+                            "team_b": team_b, "years_b": f"{start_b}-{end_b}",
+                            "overlap_years": overlap_years,
+                        },
+                    )
+                )
+
+    # Loan verification: does the loan have an owning contract?
+    for idx, stop in enumerate(career):
+        if stop.get("loan") and isinstance(stop.get("start_year"), int):
+            loan_start = stop["start_year"]
+            loan_end = stop.get("end_year") or loan_start
+            team_loan = stop.get("team")
+
+            # Look for an owning permanent contract
+            has_parent = False
+            for _, parent in permanent_stops:
+                p_start = parent["start_year"]
+                p_end = parent.get("end_year")
+                if p_start <= loan_start:
+                    if p_end is None or (isinstance(p_end, int) and loan_end <= p_end):
+                        has_parent = True
+                        break
+
+            if not has_parent:
+                findings.append(
+                    CandidateFinding(
+                        code=FindingCode.CAREER_ORPHAN_LOAN,
+                        severity=FindingSeverity.WARNING,
+                        message=(
+                            f"Prestito presso '{team_loan}' ({loan_start}-{loan_end}) non coperto "
+                            f"da un contratto permanente contestuale"
+                        ),
+                        field_path=f"career[{idx}]",
+                        context={"team": team_loan, "years": f"{loan_start}-{loan_end}"},
+                        requires_review=False,
+                    )
+                )
+
+    return findings
+
+
+def calculate_confidence_score(findings: list[CandidateFinding]) -> float:
+    """Calculates a deterministic quality confidence score in [0.0, 1.0]."""
+    has_errors = any(f.severity == FindingSeverity.ERROR for f in findings)
+    if has_errors:
+        return 0.0
+
+    score = 1.0
+    for f in findings:
+        if f.severity == FindingSeverity.WARNING:
+            # Minor penalty per warning
+            score -= 0.08
+
+    return max(0.2, round(score, 2))
+
+
+def validate_candidate(
+    candidate: CandidatePlayer,
+    current_year_provider: Optional[Callable[[], int]] = None,
+    actor: str = "service:validation",
+) -> CandidatePlayer:
+    """Validates a CandidatePlayer and updates its lifecycle state.
+
+    - Evaluates comprehensive career, player, date, and alias rules;
+    - Persists structured findings in `candidate.metadata['validation_findings']`;
+    - Populates `candidate.validation_warnings` and `candidate.validation_errors`;
+    - Computes and updates `candidate.confidence_score`;
+    - Transitions:
+        - To `VALIDATED` if zero ERROR findings;
+        - To `REVIEW_REQUIRED` if at least one ERROR (blocking) finding.
+
+    Args:
+        candidate: CandidatePlayer in NORMALIZED or REVIEW_REQUIRED state.
+        current_year_provider: Injected callable returning current year (e.g. for testing).
+        actor: System/service identifier for audit trail.
+
+    Returns:
+        The validated CandidatePlayer (mutated in-place).
+    """
+    findings = validate_candidate_data(candidate, current_year_provider=current_year_provider)
+
+    errors = [f for f in findings if f.severity == FindingSeverity.ERROR]
+    warnings = [f for f in findings if f.severity == FindingSeverity.WARNING]
+
+    # Update findings in metadata
+    candidate.metadata["validation_findings"] = [f.to_dict() for f in findings]
+
+    # Update candidate warnings and errors lists (deduplicated)
+    warning_msgs: list[str] = list(candidate.validation_warnings)
+    for w in warnings:
+        if w.message not in warning_msgs:
+            warning_msgs.append(w.message)
+    candidate.validation_warnings = warning_msgs
+
+    candidate.validation_errors = [e.message for e in errors]
+
+    # Compute confidence score
+    candidate.confidence_score = calculate_confidence_score(findings)
+
+    # State transition
+    has_blocking_errors = len(errors) > 0
+
+    if has_blocking_errors:
+        target_state = CandidateState.REVIEW_REQUIRED
+        reason = f"Validazione fallita con {len(errors)} errori bloccanti: {errors[0].message}"
+    else:
+        target_state = CandidateState.VALIDATED
+        reason = (
+            f"Validazione superata con successo ({len(warnings)} warning)"
+            if warnings
+            else "Validazione superata con successo (dati puliti)"
+        )
+
+    # Execute state transition if allowed
+    if candidate.can_transition_to(target_state):
+        candidate.transition_to(
+            target_state,
+            reason=reason,
+            actor=actor,
+            metadata={
+                "error_count": len(errors),
+                "warning_count": len(warnings),
+                "confidence_score": candidate.confidence_score,
+            },
+        )
+
+    return candidate
+
+
+def process_candidate(
+    candidate: CandidatePlayer,
+    current_year_provider: Optional[Callable[[], int]] = None,
+    actor: str = "service:pipeline",
+) -> CandidatePlayer:
+    """Convenience pipeline runner: normalizes then validates a candidate.
+
+    Follows lifecycle:
+        FETCHED -> NORMALIZED -> VALIDATED (or REVIEW_REQUIRED).
+    """
+    if candidate.status == CandidateState.FETCHED:
+        normalize_candidate(candidate, actor=f"{actor}:normalization")
+
+    if candidate.status == CandidateState.NORMALIZED:
+        validate_candidate(
+            candidate,
+            current_year_provider=current_year_provider,
+            actor=f"{actor}:validation",
+        )
+
+    return candidate

--- a/tests/test_candidate_normalization.py
+++ b/tests/test_candidate_normalization.py
@@ -1,0 +1,274 @@
+"""Unit tests for Candidate Player normalization service (#26)."""
+import copy
+
+from services.candidate_finding import CandidateFinding, FindingCode, FindingSeverity
+from services.candidate_normalization import (
+    clean_text,
+    normalize_aliases,
+    normalize_candidate,
+    normalize_club_name,
+    normalize_country,
+    normalize_league_name,
+    normalize_position,
+    strip_wiki_markup,
+)
+from services.candidate_player import CandidatePlayer, CandidateState
+
+
+def test_strip_wiki_markup_and_clean_text():
+    # Links with label
+    assert strip_wiki_markup("[[A.C. Milan|Milan]]") == "Milan"
+    # Simple links
+    assert strip_wiki_markup("[[Real Madrid]]") == "Real Madrid"
+    # Templates
+    assert strip_wiki_markup("{{Bio|...}} Francesco Totti") == "Francesco Totti"
+    # Whitespace and typography
+    assert clean_text("  Zinédine   Zidane  ") == "Zinédine Zidane"
+    assert clean_text("N’Golo Kante’") == "N'Golo Kante'"
+    assert clean_text("Paris – Saint-Germain") == "Paris - Saint-Germain"
+
+
+def test_normalize_country():
+    # IOC / ISO codes
+    assert normalize_country("ITA") == "Italia"
+    assert normalize_country("FRA") == "Francia"
+    assert normalize_country("ESP") == "Spagna"
+    assert normalize_country("DEU") == "Germania"
+    assert normalize_country("ARG") == "Argentina"
+    assert normalize_country("BRA") == "Brasile"
+    assert normalize_country("USA") == "USA"
+    # Adjectives
+    assert normalize_country("italiano") == "Italia"
+    assert normalize_country("french") == "Francia"
+    assert normalize_country("spagnolo") == "Spagna"
+    assert normalize_country("argentino") == "Argentina"
+    # Fallback to cleaned
+    assert normalize_country("San Marino") == "San Marino"
+    assert normalize_country(None) is None
+
+
+def test_normalize_position():
+    assert normalize_position("Goalkeeper") == "Portiere"
+    assert normalize_position("GK") == "Portiere"
+    assert normalize_position("difensore") == "Difensore"
+    assert normalize_position("Defender") == "Difensore"
+    assert normalize_position("Midfielder") == "Centrocampista"
+    assert normalize_position("FW") == "Attaccante"
+    assert normalize_position("Striker") == "Attaccante"
+    assert normalize_position("Ala") == "Centrocampista"
+    assert normalize_position(None) is None
+
+
+def test_normalize_aliases():
+    raw = ["Messi", "lionel messi", "Messi", " LEO MESSI  ", ""]
+    norm = normalize_aliases(raw, full_name="Lionel Andrés Messi")
+    assert norm == ["messi", "lionel messi", "leo messi", "lionel andrés messi"]
+
+
+def test_normalize_known_club_aliases():
+    # Known aliases map deterministically
+    team, findings = normalize_club_name("PSG")
+    assert team == "Paris Saint-Germain"
+    assert any(f.code == FindingCode.CLUB_NORMALIZED for f in findings)
+
+    team, _ = normalize_club_name("Man Utd")
+    assert team == "Manchester United"
+
+    team, _ = normalize_club_name("Spurs")
+    assert team == "Tottenham"
+
+    team, _ = normalize_club_name("Barcellona")
+    assert team == "Barcelona"
+
+    team, _ = normalize_club_name("Leeds")
+    assert team == "Leeds United"
+
+    team, _ = normalize_club_name("Schalke")
+    assert team == "Schalke 04"
+
+
+def test_normalize_unfamiliar_club_no_fuzzy_guess():
+    # An unfamiliar club must NOT be guessed as a famous club
+    team, findings = normalize_club_name("Real Frontera FC")
+    assert team == "Real Frontera FC"
+    # No false normalization finding
+    assert not any(f.code == FindingCode.CLUB_NORMALIZED for f in findings)
+
+    team2, _ = normalize_club_name("Barcellona Pozzo di Gotto")
+    assert team2 == "Barcellona Pozzo di Gotto"
+
+
+def test_normalize_club_unresolved_qid():
+    team, findings = normalize_club_name("Q1853")
+    assert team == "Q1853"
+    assert any(f.code == FindingCode.CLUB_UNRESOLVED_QID and f.severity == FindingSeverity.ERROR for f in findings)
+
+
+def test_normalize_ambiguous_club_alias():
+    team, findings = normalize_club_name("Sporting")
+    assert any(f.code == FindingCode.CLUB_AMBIGUOUS_ALIAS for f in findings)
+
+
+def test_normalize_league_name():
+    assert normalize_league_name("fussball bundesliga") == "Bundesliga"
+    assert normalize_league_name("primera division", "Spagna") == "La Liga"
+    assert normalize_league_name("serie a", "Brasile") == "Brasileirao"
+    assert normalize_league_name("super league", "Svizzera") == "Swiss Super League"
+
+
+def test_normalize_candidate_full_lifecycle():
+    candidate = CandidatePlayer(
+        candidate_id="cand_test_totti",
+        source="wikipedia",
+        source_id="Francesco_Totti",
+        full_name="[[Francesco Totti]]",
+        nationality="ITA",
+        position="forward",
+        aliases=["Er Pupone", "TOTTI"],
+        career=[
+            {
+                "team": "roma",
+                "start_year": "1992",
+                "end_year": "2017",
+                "loan": 0,
+                "apps": "619",
+                "goals": "250",
+            }
+        ],
+    )
+    candidate.transition_to(CandidateState.FETCHED)
+
+    norm_cand = normalize_candidate(candidate)
+
+    assert norm_cand.status == CandidateState.NORMALIZED
+    assert norm_cand.full_name == "Francesco Totti"
+    assert norm_cand.nationality == "Italia"
+    assert norm_cand.position == "Attaccante"
+    assert "er pupone" in norm_cand.aliases
+    assert "totti" in norm_cand.aliases
+    assert "francesco totti" in norm_cand.aliases
+
+    stop = norm_cand.career[0]
+    assert stop["team"] == "Roma"
+    assert stop["country"] == "Italia"
+    assert stop["league"] == "Serie A"
+    assert stop["start_year"] == 1992
+    assert stop["end_year"] == 2017
+    assert stop["loan"] is False
+    assert stop["apps"] == 619
+    assert stop["goals"] == 250
+
+    # Normalization findings in metadata
+    norm_findings = norm_cand.metadata.get("normalization_findings", [])
+    assert len(norm_findings) > 0
+
+
+def test_normalization_career_ordering():
+    # Career with loan in wrong order
+    candidate = CandidatePlayer(
+        candidate_id="cand_biabiany",
+        source="wikipedia",
+        source_id="Jonathan_Biabiany",
+        full_name="Jonathan Biabiany",
+        nationality="Francia",
+        career=[
+            {"team": "Chievo", "country": "Italia", "league": "Serie A", "start_year": 2007, "end_year": 2008, "loan": True},
+            {"team": "Inter", "country": "Italia", "league": "Serie A", "start_year": 2007, "end_year": 2010},
+        ],
+    )
+    candidate.transition_to(CandidateState.FETCHED)
+
+    normalize_candidate(candidate)
+
+    assert candidate.status == CandidateState.NORMALIZED
+    # Canonical order: Inter first, then Chievo loan
+    assert candidate.career[0]["team"] == "Inter"
+    assert candidate.career[1]["team"] == "Chievo"
+
+
+def test_normalization_idempotency():
+    candidate = CandidatePlayer(
+        candidate_id="cand_messi_idempotent",
+        source="wikipedia",
+        source_id="Lionel_Messi",
+        full_name="Lionel Messi",
+        nationality="ARG",
+        position="forward",
+        aliases=["messi", "leo messi"],
+        career=[
+            {"team": "barcelona", "start_year": "2004", "end_year": "2021", "loan": False},
+            {"team": "psg", "country": "Francia", "league": "Ligue 1", "start_year": "2021", "end_year": "2023"},
+        ],
+    )
+    candidate.transition_to(CandidateState.FETCHED)
+
+    # First normalization run
+    normalize_candidate(candidate)
+    assert candidate.status == CandidateState.NORMALIZED
+    snapshot_1 = copy.deepcopy(candidate.to_dict())
+
+    # Second normalization run on the same candidate
+    normalize_candidate(candidate)
+    snapshot_2 = copy.deepcopy(candidate.to_dict())
+
+    # State, career, and warnings should be completely stable
+    assert snapshot_1["status"] == snapshot_2["status"]
+    assert snapshot_1["full_name"] == snapshot_2["full_name"]
+    assert snapshot_1["nationality"] == snapshot_2["nationality"]
+    assert snapshot_1["position"] == snapshot_2["position"]
+    assert snapshot_1["career"] == snapshot_2["career"]
+    assert snapshot_1["aliases"] == snapshot_2["aliases"]
+    assert snapshot_1["validation_warnings"] == snapshot_2["validation_warnings"]
+    assert snapshot_1["metadata"]["normalization_findings"] == snapshot_2["metadata"]["normalization_findings"]
+    # State history should not have an additional redundant transition
+    assert len(snapshot_1["state_history"]) == len(snapshot_2["state_history"])
+
+
+def test_wikipedia_shaped_candidate():
+    """Candidate populated from Wikipedia raw adapter wikitext."""
+    candidate = CandidatePlayer(
+        candidate_id="cand_wiki_del_piero",
+        source="wikipedia",
+        source_id="Alessandro_Del_Piero",
+        full_name="[[Alessandro Del Piero]]",
+        nationality="italiano",
+        position="Attaccante",
+        aliases=["Pinturicchio", "Del Piero"],
+        career=[
+            {"team": "Padova", "country": "Italia", "league": "Serie B", "start_year": 1991, "end_year": 1993},
+            {"team": "Juventus", "country": "Italia", "league": "Serie A", "start_year": 1993, "end_year": 2012},
+            {"team": "Sydney FC", "country": "Australia", "league": "A-League", "start_year": 2012, "end_year": 2014},
+        ],
+    )
+    candidate.transition_to(CandidateState.FETCHED)
+    normalize_candidate(candidate)
+
+    assert candidate.status == CandidateState.NORMALIZED
+    assert candidate.full_name == "Alessandro Del Piero"
+    assert candidate.nationality == "Italia"
+    assert "del piero" in candidate.aliases
+
+
+def test_wikidata_shaped_candidate_with_qids():
+    """Candidate populated from Wikidata with unresolved QIDs."""
+    candidate = CandidatePlayer(
+        candidate_id="cand_wd_unresolved",
+        source="wikidata",
+        source_id="Q12345",
+        full_name="Q12345",
+        nationality="ITA",
+        position="MF",
+        career=[
+            {"team": "Q1853", "start_year": 2015, "end_year": 2020},
+        ],
+    )
+    candidate.transition_to(CandidateState.FETCHED)
+    normalize_candidate(candidate)
+
+    # QIDs must NOT be pretended to be resolved club names
+    assert candidate.status == CandidateState.NORMALIZED
+    assert candidate.full_name == "Q12345"
+    assert candidate.career[0]["team"] == "Q1853"
+    findings = [CandidateFinding.from_dict(d) for d in candidate.metadata["normalization_findings"]]
+    assert any(f.code == FindingCode.PLAYER_NAME_MALFORMED for f in findings)
+    assert any(f.code == FindingCode.CLUB_UNRESOLVED_QID for f in findings)

--- a/tests/test_candidate_normalization.py
+++ b/tests/test_candidate_normalization.py
@@ -10,6 +10,8 @@ from services.candidate_normalization import (
     normalize_country,
     normalize_league_name,
     normalize_position,
+    parse_loan_flag,
+    resolve_historical_league_with_temporal_evidence,
     strip_wiki_markup,
 )
 from services.candidate_player import CandidatePlayer, CandidateState
@@ -104,9 +106,97 @@ def test_normalize_club_unresolved_qid():
     assert any(f.code == FindingCode.CLUB_UNRESOLVED_QID and f.severity == FindingSeverity.ERROR for f in findings)
 
 
-def test_normalize_ambiguous_club_alias():
-    team, findings = normalize_club_name("Sporting")
-    assert any(f.code == FindingCode.CLUB_AMBIGUOUS_ALIAS for f in findings)
+def test_normalize_ambiguous_club_aliases_never_silently_resolved():
+    """Ambiguous club aliases (Sporting, Inter, Real, Racing, etc.) must NEVER be silently resolved."""
+    ambiguous_examples = ["Sporting", "Inter", "Real", "Racing", "Nacional", "Dynamo", "Dinamo", "United", "City"]
+    for raw_name in ambiguous_examples:
+        team, findings = normalize_club_name(raw_name)
+        # Preserves cleaned original value without mapping to a canonical club
+        assert team == raw_name
+        # Emits CLUB_AMBIGUOUS_ALIAS
+        assert any(f.code == FindingCode.CLUB_AMBIGUOUS_ALIAS for f in findings), f"Expected CLUB_AMBIGUOUS_ALIAS for {raw_name}"
+        # Does NOT emit CLUB_NORMALIZED
+        assert not any(f.code == FindingCode.CLUB_NORMALIZED for f in findings), f"Unexpected CLUB_NORMALIZED for {raw_name}"
+
+
+def test_parse_loan_flag_safe():
+    """Deterministic parsing for booleans, ints, and string representations."""
+    # Booleans
+    assert parse_loan_flag(True) is True
+    assert parse_loan_flag(False) is False
+
+    # Integers
+    assert parse_loan_flag(1) is True
+    assert parse_loan_flag(0) is False
+
+    # Strings: true / 1
+    assert parse_loan_flag("true") is True
+    assert parse_loan_flag("True") is True
+    assert parse_loan_flag(" TRUE ") is True
+    assert parse_loan_flag("1") is True
+
+    # Strings: false / 0
+    assert parse_loan_flag("false") is False
+    assert parse_loan_flag("False") is False
+    assert parse_loan_flag(" FALSE ") is False
+    assert parse_loan_flag("0") is False
+
+    # Unknown or arbitrary values must NOT silently become True
+    assert parse_loan_flag("si") is None
+    assert parse_loan_flag("yes") is None
+    assert parse_loan_flag("arbitrary") is None
+    assert parse_loan_flag(2) is None
+    assert parse_loan_flag(-1) is None
+    assert parse_loan_flag(None) is False
+
+
+def test_career_stop_loan_string_normalization():
+    """String 'false' and '0' in career stops must normalize to boolean False, not True."""
+    cand = CandidatePlayer(
+        candidate_id="cand_loan_strings",
+        source="wikipedia",
+        source_id="Loan_Test",
+        full_name="Loan Test",
+        nationality="ITA",
+        career=[
+            {"team": "Milan", "country": "Italia", "league": "Serie A", "start_year": 2010, "end_year": 2012, "loan": "false"},
+            {"team": "Monza", "country": "Italia", "league": "Serie A", "start_year": 2012, "end_year": 2014, "loan": "0"},
+            {"team": "Napoli", "country": "Italia", "league": "Serie A", "start_year": 2014, "end_year": 2016, "loan": "true"},
+            {"team": "Genoa", "country": "Italia", "league": "Serie A", "start_year": 2016, "end_year": 2018, "loan": "1"},
+        ],
+    )
+    cand.transition_to(CandidateState.FETCHED)
+    normalize_candidate(cand)
+
+    assert cand.career[0]["loan"] is False
+    assert cand.career[1]["loan"] is False
+    assert cand.career[2]["loan"] is True
+    assert cand.career[3]["loan"] is True
+
+
+def test_known_club_missing_league_remains_missing():
+    """A known club with missing league must keep league as missing (not guessed)."""
+    candidate = CandidatePlayer(
+        candidate_id="cand_known_club_league",
+        source="wikipedia",
+        source_id="Roma_Player",
+        full_name="Roma Player",
+        nationality="ITA",
+        career=[
+            {"team": "Roma", "start_year": 2010, "end_year": 2015}
+        ],
+    )
+    candidate.transition_to(CandidateState.FETCHED)
+    normalize_candidate(candidate)
+
+    stop = candidate.career[0]
+    assert stop["team"] == "Roma"
+    # Country is inferred because Roma is unambiguous
+    assert stop["country"] == "Italia"
+    # League is NOT inferred and remains missing
+    assert stop.get("league") is None
+    # Explicit extension point is present and returns None until season-aware resolution is implemented
+    assert resolve_historical_league_with_temporal_evidence("Roma", "Italia", 2010, 2015) is None
 
 
 def test_normalize_league_name():
@@ -130,7 +220,7 @@ def test_normalize_candidate_full_lifecycle():
                 "team": "roma",
                 "start_year": "1992",
                 "end_year": "2017",
-                "loan": 0,
+                "loan": "false",
                 "apps": "619",
                 "goals": "250",
             }
@@ -151,9 +241,11 @@ def test_normalize_candidate_full_lifecycle():
     stop = norm_cand.career[0]
     assert stop["team"] == "Roma"
     assert stop["country"] == "Italia"
-    assert stop["league"] == "Serie A"
+    # Historical league is preserved missing without temporal evidence
+    assert stop.get("league") is None
     assert stop["start_year"] == 1992
     assert stop["end_year"] == 2017
+    # String "false" deterministically parsed to boolean False
     assert stop["loan"] is False
     assert stop["apps"] == 619
     assert stop["goals"] == 250

--- a/tests/test_candidate_validation.py
+++ b/tests/test_candidate_validation.py
@@ -1,0 +1,489 @@
+"""Unit tests for Candidate Player validation service (#26)."""
+import hashlib
+import os
+
+from services.candidate_finding import CandidateFinding, FindingCode, FindingSeverity
+from services.candidate_player import CandidatePlayer, CandidateState
+from services.candidate_validation import (
+    process_candidate,
+    validate_candidate,
+)
+
+_PLAYERS_PATH = os.path.join(os.path.dirname(os.path.dirname(os.path.abspath(__file__))), "data", "players.json")
+
+
+def _get_players_json_hash() -> str:
+    with open(_PLAYERS_PATH, "rb") as f:
+        return hashlib.sha256(f.read()).hexdigest()
+
+
+def test_clean_valid_career_transitions_to_validated():
+    """A clean, coherent candidate transitions NORMALIZED -> VALIDATED."""
+    candidate = CandidatePlayer(
+        candidate_id="cand_valid_messi",
+        source="wikipedia",
+        source_id="Lionel_Messi",
+        full_name="Lionel Messi",
+        nationality="Argentina",
+        position="Attaccante",
+        birth_year=1987,
+        aliases=["messi", "leo messi"],
+        career=[
+            {"team": "Barcelona", "country": "Spagna", "league": "La Liga", "start_year": 2004, "end_year": 2021},
+            {"team": "Paris Saint-Germain", "country": "Francia", "league": "Ligue 1", "start_year": 2021, "end_year": 2023},
+            {"team": "Inter Miami", "country": "USA", "league": "MLS", "start_year": 2023, "end_year": None},
+        ],
+    )
+    candidate.transition_to(CandidateState.FETCHED)
+    candidate.transition_to(CandidateState.NORMALIZED)
+
+    validated = validate_candidate(candidate, current_year_provider=lambda: 2026)
+
+    assert validated.status == CandidateState.VALIDATED
+    assert validated.validation_errors == []
+    assert validated.confidence_score is not None
+    assert validated.confidence_score >= 0.9
+
+
+def test_empty_career_transitions_to_review_required():
+    candidate = CandidatePlayer(
+        candidate_id="cand_empty_career",
+        source="wikipedia",
+        source_id="Player_Empty",
+        full_name="Player Empty",
+        nationality="Italia",
+        position="Centrocampista",
+        career=[],
+    )
+    candidate.transition_to(CandidateState.FETCHED)
+    candidate.transition_to(CandidateState.NORMALIZED)
+
+    validate_candidate(candidate)
+
+    assert candidate.status == CandidateState.REVIEW_REQUIRED
+    assert any("Carriera vuota" in err for err in candidate.validation_errors)
+    findings = [CandidateFinding.from_dict(d) for d in candidate.metadata["validation_findings"]]
+    assert any(f.code == FindingCode.CAREER_EMPTY and f.severity == FindingSeverity.ERROR for f in findings)
+
+
+def test_single_team_without_one_club_flag_requires_review():
+    candidate = CandidatePlayer(
+        candidate_id="cand_short_career",
+        source="wikipedia",
+        source_id="Short_Career",
+        full_name="Short Career",
+        nationality="Italia",
+        position="Difensore",
+        career=[
+            {"team": "Milan", "country": "Italia", "league": "Serie A", "start_year": 2010, "end_year": 2015}
+        ],
+    )
+    candidate.transition_to(CandidateState.FETCHED)
+    candidate.transition_to(CandidateState.NORMALIZED)
+
+    validate_candidate(candidate)
+
+    assert candidate.status == CandidateState.REVIEW_REQUIRED
+    findings = [CandidateFinding.from_dict(d) for d in candidate.metadata["validation_findings"]]
+    assert any(f.code == FindingCode.CAREER_TOO_SHORT for f in findings)
+
+
+def test_single_team_with_one_club_flag_is_valid():
+    candidate = CandidatePlayer(
+        candidate_id="cand_one_club_totti",
+        source="wikipedia",
+        source_id="Francesco_Totti",
+        full_name="Francesco Totti",
+        nationality="Italia",
+        position="Attaccante",
+        birth_year=1976,
+        career=[
+            {"team": "Roma", "country": "Italia", "league": "Serie A", "start_year": 1992, "end_year": 2017}
+        ],
+        metadata={"one_club_career": True},
+    )
+    candidate.transition_to(CandidateState.FETCHED)
+    candidate.transition_to(CandidateState.NORMALIZED)
+
+    validate_candidate(candidate, current_year_provider=lambda: 2026)
+
+    assert candidate.status == CandidateState.VALIDATED
+    assert candidate.validation_errors == []
+
+
+def test_duplicate_stop_requires_review():
+    candidate = CandidatePlayer(
+        candidate_id="cand_duplicate_stop",
+        source="wikipedia",
+        source_id="Dup_Stop",
+        full_name="Dup Stop",
+        nationality="Italia",
+        position="Centrocampista",
+        career=[
+            {"team": "Juventus", "country": "Italia", "league": "Serie A", "start_year": 2015, "end_year": 2018},
+            {"team": "Juventus", "country": "Italia", "league": "Serie A", "start_year": 2015, "end_year": 2018},
+        ],
+    )
+    candidate.transition_to(CandidateState.FETCHED)
+    candidate.transition_to(CandidateState.NORMALIZED)
+
+    validate_candidate(candidate)
+
+    assert candidate.status == CandidateState.REVIEW_REQUIRED
+    findings = [CandidateFinding.from_dict(d) for d in candidate.metadata["validation_findings"]]
+    assert any(f.code == FindingCode.CAREER_DUPLICATE_STOP for f in findings)
+
+
+def test_same_club_in_distinct_legitimate_periods_is_valid():
+    """Returns to a previous club in separated years (e.g. Lukaku or Pogba) is valid."""
+    candidate = CandidatePlayer(
+        candidate_id="cand_return_club",
+        source="wikipedia",
+        source_id="Return_Player",
+        full_name="Return Player",
+        nationality="Belgio",
+        position="Attaccante",
+        birth_year=1993,
+        career=[
+            {"team": "Chelsea", "country": "Inghilterra", "league": "Premier League", "start_year": 2011, "end_year": 2014},
+            {"team": "Everton", "country": "Inghilterra", "league": "Premier League", "start_year": 2014, "end_year": 2017},
+            {"team": "Chelsea", "country": "Inghilterra", "league": "Premier League", "start_year": 2021, "end_year": 2022},
+        ],
+    )
+    candidate.transition_to(CandidateState.FETCHED)
+    candidate.transition_to(CandidateState.NORMALIZED)
+
+    validate_candidate(candidate, current_year_provider=lambda: 2026)
+
+    assert candidate.status == CandidateState.VALIDATED
+    assert candidate.validation_errors == []
+
+
+def test_invalid_start_end_range():
+    # 1. end_year < start_year
+    cand1 = CandidatePlayer(
+        candidate_id="cand_invalid_years",
+        source="wikipedia",
+        source_id="Inv_Years",
+        full_name="Inv Years",
+        nationality="Spagna",
+        career=[
+            {"team": "Valencia", "country": "Spagna", "league": "La Liga", "start_year": 2015, "end_year": 2010},
+            {"team": "Villarreal", "country": "Spagna", "league": "La Liga", "start_year": 2016, "end_year": 2018},
+        ],
+    )
+    cand1.transition_to(CandidateState.FETCHED)
+    cand1.transition_to(CandidateState.NORMALIZED)
+    validate_candidate(cand1)
+    assert cand1.status == CandidateState.REVIEW_REQUIRED
+    findings1 = [CandidateFinding.from_dict(d) for d in cand1.metadata["validation_findings"]]
+    assert any(f.code == FindingCode.CAREER_INVALID_RANGE for f in findings1)
+
+    # 2. debut before age 14
+    cand2 = CandidatePlayer(
+        candidate_id="cand_child_debut",
+        source="wikipedia",
+        source_id="Child_Debut",
+        full_name="Child Debut",
+        nationality="Spagna",
+        birth_year=2000,
+        career=[
+            {"team": "Betis", "country": "Spagna", "league": "La Liga", "start_year": 2010, "end_year": 2015},
+            {"team": "Sevilla", "country": "Spagna", "league": "La Liga", "start_year": 2015, "end_year": 2020},
+        ],
+    )
+    cand2.transition_to(CandidateState.FETCHED)
+    cand2.transition_to(CandidateState.NORMALIZED)
+    validate_candidate(cand2)
+    assert cand2.status == CandidateState.REVIEW_REQUIRED
+
+
+def test_future_year_detection_with_injected_provider():
+    candidate = CandidatePlayer(
+        candidate_id="cand_future_year",
+        source="wikipedia",
+        source_id="Future_Year",
+        full_name="Future Year",
+        nationality="Germania",
+        career=[
+            {"team": "Dortmund", "country": "Germania", "league": "Bundesliga", "start_year": 2020, "end_year": 2035},
+            {"team": "Bayern", "country": "Germania", "league": "Bundesliga", "start_year": 2035, "end_year": 2038},
+        ],
+    )
+    candidate.transition_to(CandidateState.FETCHED)
+    candidate.transition_to(CandidateState.NORMALIZED)
+
+    # Injected current year = 2026
+    validate_candidate(candidate, current_year_provider=lambda: 2026)
+
+    assert candidate.status == CandidateState.REVIEW_REQUIRED
+    findings = [CandidateFinding.from_dict(d) for d in candidate.metadata["validation_findings"]]
+    assert any(f.code == FindingCode.CAREER_FUTURE_YEAR for f in findings)
+
+
+def test_ongoing_career_valid_at_tail_invalid_in_middle():
+    # Valid ongoing career (None at last stop)
+    cand_tail = CandidatePlayer(
+        candidate_id="cand_ongoing_tail",
+        source="wikipedia",
+        source_id="Tail_Ongoing",
+        full_name="Tail Ongoing",
+        nationality="Italia",
+        career=[
+            {"team": "Atalanta", "country": "Italia", "league": "Serie A", "start_year": 2018, "end_year": 2022},
+            {"team": "Lazio", "country": "Italia", "league": "Serie A", "start_year": 2022, "end_year": None},
+        ],
+    )
+    cand_tail.transition_to(CandidateState.FETCHED)
+    cand_tail.transition_to(CandidateState.NORMALIZED)
+    validate_candidate(cand_tail, current_year_provider=lambda: 2026)
+    assert cand_tail.status == CandidateState.VALIDATED
+
+    # Invalid ongoing career (None in middle with later stops starting after)
+    cand_mid = CandidatePlayer(
+        candidate_id="cand_ongoing_mid",
+        source="wikipedia",
+        source_id="Mid_Ongoing",
+        full_name="Mid Ongoing",
+        nationality="Italia",
+        career=[
+            {"team": "Atalanta", "country": "Italia", "league": "Serie A", "start_year": 2018, "end_year": None},
+            {"team": "Lazio", "country": "Italia", "league": "Serie A", "start_year": 2022, "end_year": 2024},
+        ],
+    )
+    cand_mid.transition_to(CandidateState.FETCHED)
+    cand_mid.transition_to(CandidateState.NORMALIZED)
+    validate_candidate(cand_mid, current_year_provider=lambda: 2026)
+    assert cand_mid.status == CandidateState.REVIEW_REQUIRED
+
+
+def test_legitimate_same_year_transfer_is_valid():
+    candidate = CandidatePlayer(
+        candidate_id="cand_same_year_transfer",
+        source="wikipedia",
+        source_id="Same_Year",
+        full_name="Same Year",
+        nationality="Italia",
+        career=[
+            {"team": "Sampdoria", "country": "Italia", "league": "Serie A", "start_year": 2015, "end_year": 2018},
+            {"team": "Torino", "country": "Italia", "league": "Serie A", "start_year": 2018, "end_year": 2021},
+        ],
+    )
+    candidate.transition_to(CandidateState.FETCHED)
+    candidate.transition_to(CandidateState.NORMALIZED)
+    validate_candidate(candidate, current_year_provider=lambda: 2026)
+    assert candidate.status == CandidateState.VALIDATED
+
+
+def test_legitimate_loan_overlap_is_valid():
+    """Loan covered by parent contract is valid."""
+    candidate = CandidatePlayer(
+        candidate_id="cand_valid_loan",
+        source="wikipedia",
+        source_id="Loan_Player",
+        full_name="Loan Player",
+        nationality="Italia",
+        career=[
+            {"team": "Inter", "country": "Italia", "league": "Serie A", "start_year": 2015, "end_year": 2020},
+            {"team": "Chievo", "country": "Italia", "league": "Serie A", "start_year": 2016, "end_year": 2017, "loan": True},
+            {"team": "Monza", "country": "Italia", "league": "Serie A", "start_year": 2020, "end_year": 2023},
+        ],
+    )
+    candidate.transition_to(CandidateState.FETCHED)
+    candidate.transition_to(CandidateState.NORMALIZED)
+    validate_candidate(candidate, current_year_provider=lambda: 2026)
+    assert candidate.status == CandidateState.VALIDATED
+
+
+def test_suspicious_multi_year_permanent_overlap_requires_review():
+    """Two permanent contracts overlapping by multiple years is impossible."""
+    candidate = CandidatePlayer(
+        candidate_id="cand_suspicious_overlap",
+        source="wikipedia",
+        source_id="Overlap_Player",
+        full_name="Overlap Player",
+        nationality="Francia",
+        career=[
+            {"team": "Lyon", "country": "Francia", "league": "Ligue 1", "start_year": 2010, "end_year": 2016},
+            {"team": "Marseille", "country": "Francia", "league": "Ligue 1", "start_year": 2012, "end_year": 2018},
+        ],
+    )
+    candidate.transition_to(CandidateState.FETCHED)
+    candidate.transition_to(CandidateState.NORMALIZED)
+    validate_candidate(candidate, current_year_provider=lambda: 2026)
+
+    assert candidate.status == CandidateState.REVIEW_REQUIRED
+    findings = [CandidateFinding.from_dict(d) for d in candidate.metadata["validation_findings"]]
+    assert any(f.code == FindingCode.CAREER_OVERLAP for f in findings)
+
+
+def test_missing_country_and_league_require_review():
+    candidate = CandidatePlayer(
+        candidate_id="cand_missing_data",
+        source="wikipedia",
+        source_id="Missing_Data",
+        full_name="Missing Data",
+        nationality="Italia",
+        career=[
+            {"team": "UnknownClub", "country": None, "league": None, "start_year": 2015, "end_year": 2018},
+            {"team": "Milan", "country": "Italia", "league": "Serie A", "start_year": 2018, "end_year": 2021},
+        ],
+    )
+    candidate.transition_to(CandidateState.FETCHED)
+    candidate.transition_to(CandidateState.NORMALIZED)
+    validate_candidate(candidate)
+
+    assert candidate.status == CandidateState.REVIEW_REQUIRED
+    findings = [CandidateFinding.from_dict(d) for d in candidate.metadata["validation_findings"]]
+    assert any(f.code == FindingCode.CLUB_MISSING_COUNTRY for f in findings)
+    assert any(f.code == FindingCode.CLUB_MISSING_LEAGUE for f in findings)
+
+
+def test_malformed_player_and_club_names():
+    # 1. Player name is raw Wikidata QID
+    cand1 = CandidatePlayer(
+        candidate_id="cand_qid_player",
+        source="wikidata",
+        source_id="Q9999",
+        full_name="Q9999",
+        nationality="Italia",
+        career=[
+            {"team": "Roma", "country": "Italia", "league": "Serie A", "start_year": 2015, "end_year": 2018},
+            {"team": "Lazio", "country": "Italia", "league": "Serie A", "start_year": 2018, "end_year": 2021},
+        ],
+    )
+    cand1.transition_to(CandidateState.FETCHED)
+    cand1.transition_to(CandidateState.NORMALIZED)
+    validate_candidate(cand1)
+    assert cand1.status == CandidateState.REVIEW_REQUIRED
+    findings1 = [CandidateFinding.from_dict(d) for d in cand1.metadata["validation_findings"]]
+    assert any(f.code == FindingCode.PLAYER_NAME_MALFORMED for f in findings1)
+
+    # 2. Club name is raw Wikidata QID
+    cand2 = CandidatePlayer(
+        candidate_id="cand_qid_club",
+        source="wikidata",
+        source_id="Player_QID_Club",
+        full_name="Good Player",
+        nationality="Italia",
+        career=[
+            {"team": "Q1853", "country": "Italia", "league": "Serie A", "start_year": 2015, "end_year": 2018},
+            {"team": "Lazio", "country": "Italia", "league": "Serie A", "start_year": 2018, "end_year": 2021},
+        ],
+    )
+    cand2.transition_to(CandidateState.FETCHED)
+    cand2.transition_to(CandidateState.NORMALIZED)
+    validate_candidate(cand2)
+    assert cand2.status == CandidateState.REVIEW_REQUIRED
+    findings2 = [CandidateFinding.from_dict(d) for d in cand2.metadata["validation_findings"]]
+    assert any(f.code == FindingCode.CLUB_UNRESOLVED_QID for f in findings2)
+
+
+def test_ambiguous_alias_with_existing_production_player():
+    """An alias that collides with an existing production player requires review."""
+    candidate = CandidatePlayer(
+        candidate_id="cand_colliding_alias",
+        source="wikipedia",
+        source_id="Different_Messi",
+        full_name="Other Guy",
+        nationality="Spagna",
+        aliases=["lionel messi"],  # Belongs to production player 'messi'
+        career=[
+            {"team": "Sevilla", "country": "Spagna", "league": "La Liga", "start_year": 2015, "end_year": 2018},
+            {"team": "Betis", "country": "Spagna", "league": "La Liga", "start_year": 2018, "end_year": 2021},
+        ],
+    )
+    candidate.transition_to(CandidateState.FETCHED)
+    candidate.transition_to(CandidateState.NORMALIZED)
+    validate_candidate(candidate)
+
+    assert candidate.status == CandidateState.REVIEW_REQUIRED
+    findings = [CandidateFinding.from_dict(d) for d in candidate.metadata["validation_findings"]]
+    assert any(f.code == FindingCode.PLAYER_ALIAS_AMBIGUOUS for f in findings)
+
+
+def test_structured_finding_serialization():
+    finding = CandidateFinding(
+        code=FindingCode.CAREER_DUPLICATE_STOP,
+        severity=FindingSeverity.ERROR,
+        message="Tappa duplicata",
+        field_path="career[1]",
+        input_value={"team": "Inter"},
+        context={"index": 1},
+        requires_review=True,
+    )
+    serialized = finding.to_dict()
+    restored = CandidateFinding.from_dict(serialized)
+
+    assert restored.code == finding.code
+    assert restored.severity == finding.severity
+    assert restored.message == finding.message
+    assert restored.field_path == finding.field_path
+    assert restored.input_value == finding.input_value
+    assert restored.context == finding.context
+    assert restored.requires_review is True
+
+
+def test_end_to_end_process_candidate_pipeline():
+    """Full lifecycle execution: FETCHED -> NORMALIZED -> VALIDATED."""
+    candidate = CandidatePlayer(
+        candidate_id="cand_e2e_totti",
+        source="wikipedia",
+        source_id="Francesco_Totti",
+        full_name="[[Francesco Totti]]",
+        nationality="ITA",
+        position="forward",
+        aliases=["Er Pupone"],
+        career=[
+            {"team": "roma", "start_year": "1992", "end_year": "2017"}
+        ],
+        metadata={"one_club_career": True},
+    )
+    candidate.transition_to(CandidateState.FETCHED)
+
+    processed = process_candidate(candidate, current_year_provider=lambda: 2026)
+
+    assert processed.status == CandidateState.VALIDATED
+    assert processed.full_name == "Francesco Totti"
+    assert processed.nationality == "Italia"
+    assert processed.position == "Attaccante"
+    assert processed.career[0]["team"] == "Roma"
+    assert processed.career[0]["country"] == "Italia"
+    assert processed.career[0]["league"] == "Serie A"
+    assert processed.career[0]["start_year"] == 1992
+    assert processed.career[0]["end_year"] == 2017
+
+
+def test_production_dataset_safety_invariant():
+    """CRITICAL SAFETY TEST: Normalization and validation must NEVER modify data/players.json."""
+    initial_hash = _get_players_json_hash()
+
+    # Create various dirty, clean, and corrupt candidates
+    candidates = [
+        CandidatePlayer(
+            candidate_id="cand_safe_1",
+            source="wikipedia",
+            source_id="Clean",
+            full_name="Clean Player",
+            nationality="Italia",
+            career=[
+                {"team": "Milan", "country": "Italia", "league": "Serie A", "start_year": 2010, "end_year": 2015},
+                {"team": "Juventus", "country": "Italia", "league": "Serie A", "start_year": 2015, "end_year": 2020},
+            ],
+        ),
+        CandidatePlayer(
+            candidate_id="cand_safe_2",
+            source="wikidata",
+            source_id="Corrupt",
+            full_name="Q9999",
+            nationality="XYZ",
+            career=[],
+        ),
+    ]
+
+    for cand in candidates:
+        cand.transition_to(CandidateState.FETCHED)
+        process_candidate(cand)
+
+    final_hash = _get_players_json_hash()
+    assert initial_hash == final_hash, "data/players.json was modified! Safety invariant violated!"

--- a/tests/test_candidate_validation.py
+++ b/tests/test_candidate_validation.py
@@ -435,7 +435,7 @@ def test_end_to_end_process_candidate_pipeline():
         position="forward",
         aliases=["Er Pupone"],
         career=[
-            {"team": "roma", "start_year": "1992", "end_year": "2017"}
+            {"team": "roma", "league": "Serie A", "start_year": "1992", "end_year": "2017"}
         ],
         metadata={"one_club_career": True},
     )
@@ -452,6 +452,40 @@ def test_end_to_end_process_candidate_pipeline():
     assert processed.career[0]["league"] == "Serie A"
     assert processed.career[0]["start_year"] == 1992
     assert processed.career[0]["end_year"] == 2017
+
+
+def test_known_club_missing_league_regression():
+    """Regression test: known club with missing league must NEVER infer league from identity alone.
+
+    Country may be inferred if unambiguous, but league remains missing and validation emits CLUB_MISSING_LEAGUE.
+    """
+    candidate = CandidatePlayer(
+        candidate_id="cand_known_club_no_league",
+        source="wikipedia",
+        source_id="Test_Player",
+        full_name="Test Player",
+        nationality="Italia",
+        position="Attaccante",
+        career=[
+            {"team": "Juventus", "start_year": 2015, "end_year": 2018},
+            {"team": "Milan", "country": "Italia", "league": "Serie A", "start_year": 2018, "end_year": 2021},
+        ],
+    )
+    candidate.transition_to(CandidateState.FETCHED)
+
+    processed = process_candidate(candidate, current_year_provider=lambda: 2026)
+
+    # Juventus is known and unambiguous, so country is backfilled to Italia
+    assert processed.career[0]["country"] == "Italia"
+    # Historical league must NOT be backfilled and remains missing
+    assert processed.career[0].get("league") is None
+    # Validation must emit CLUB_MISSING_LEAGUE and flag for review
+    assert processed.status == CandidateState.REVIEW_REQUIRED
+    findings = [CandidateFinding.from_dict(d) for d in processed.metadata["validation_findings"]]
+    assert any(
+        f.code == FindingCode.CLUB_MISSING_LEAGUE and f.field_path == "career[0].league"
+        for f in findings
+    )
 
 
 def test_production_dataset_safety_invariant():


### PR DESCRIPTION
Closes #26

### Summary
Introduces a deterministic, isolated, and reusable normalization and validation service for Candidate Players in `guess_the_player_from_the_path`. The service standardizes player and career data ingested from Wikipedia and Wikidata adapters (#14), detects data anomalies (malformed names, impossible date ranges, overlapping permanent contracts, duplicate stops, unclassified clubs), and enforces the Candidate Player lifecycle state machine (#54) transitioning candidates to `VALIDATED` or `REVIEW_REQUIRED`.

### Normalization architecture
- Implemented in `services/candidate_normalization.py`.
- Deterministic text cleaning: whitespace stripping, Unicode NFC normalization, typographic quote and dash standardizations, removal of wiki templates (`{{...}}`) and links (`[[Target|Label]]`).
- Standardizes nationality into canonical Italian country names (using IOC/ISO 3166 code tables and adjective dictionaries).
- Standardizes positions into standard Italian football roles (`Portiere`, `Difensore`, `Centrocampista`, `Attaccante`).
- Standardizes aliases: lowercase, whitespace trimmed, deduplicated with stable ordering.
- Standardizes career stops: numeric conversion of `start_year`, `end_year`, `apps`, `goals`, boolean conversion of `loan`.
- Integrates `order_career()` from `services/career_order.py` to enforce canonical Wikipedia ordering (clubs precede loans).
- Idempotency guarantee: re-running normalization on an already normalized candidate is idempotent and preserves findings.

### Validation architecture
- Implemented in `services/candidate_validation.py`.
- Injectable current year provider (`Callable[[], int]`), avoiding hardcoded years and ensuring test resilience across time.
- Verifies player-level fields: name emptiness/length/markup/QID, missing nationality, implausible birth year, and ambiguous aliases.
- Verifies career structure: empty career (`CAREER_EMPTY`), single-team career without `one_club_career` flag (`CAREER_TOO_SHORT`), and one-club flag mismatches.
- Verifies stop-level fields: missing/malformed club names, unresolved QIDs, missing country (`CLUB_MISSING_COUNTRY`), missing league (`CLUB_MISSING_LEAGUE`), negative apps/goals.
- Evaluates date validity: `start_year < 1890`, `start_year > current_year`, `end_year < start_year`, `end_year > current_year`, debut before age 14, and `end_year=None` on non-terminal stops.
- Analyzes overlaps: differentiates legitimate loans, same-year transfers (`A.end == B.start`), multiple clubs in the same season, and returns to previous clubs from impossible multi-year permanent contract overlaps.
- Computes deterministic `confidence_score` in [0.0, 1.0].

### Structured findings
- Implemented in `services/candidate_finding.py`.
- `FindingSeverity`: `WARNING` (non-blocking) and `ERROR` (blocking, human review required).
- `CandidateFinding`: dataclass storing `code`, `severity`, `message`, `field_path`, `input_value`, `context`, and `requires_review`.
- Stable taxonomy codes including: `CAREER_EMPTY`, `CAREER_TOO_SHORT`, `CAREER_ONE_CLUB_MISMATCH`, `CAREER_DUPLICATE_STOP`, `CAREER_INVALID_RANGE`, `CAREER_FUTURE_YEAR`, `CAREER_OVERLAP`, `CAREER_ORPHAN_LOAN`, `CAREER_ORDER`, `CAREER_APPS_GOALS_INVALID`, `CLUB_NAME_MISSING`, `CLUB_NAME_MALFORMED`, `CLUB_UNRESOLVED_QID`, `CLUB_MISSING_COUNTRY`, `CLUB_MISSING_LEAGUE`, `CLUB_COUNTRY_MISMATCH`, `CLUB_AMBIGUOUS_ALIAS`, `PLAYER_NAME_EMPTY`, `PLAYER_NAME_MALFORMED`, `PLAYER_NATIONALITY_MISSING`, `PLAYER_POSITION_MISSING`, `PLAYER_BIRTH_YEAR_IMPLAUSIBLE`, `PLAYER_ALIAS_MALFORMED`, `PLAYER_ALIAS_AMBIGUOUS`.
- Full JSON serialization (`to_dict()`, `from_dict()`) stored in `candidate.metadata['normalization_findings']` and `candidate.metadata['validation_findings']`.

### Club alias strategy
- Consolidated repository sources of truth from `scripts/wikipedia/clubs.py` and `scripts/wikipedia/normalize_batch.py` into `CONSOLIDATED_CLUB_ALIASES`.
- Utilizes read-only canonical club index from `data/players.json` for deterministic alignment of existing club names.
- Unfamiliar clubs are NOT guessed via Levenshtein/fuzzy matching: unknown names are preserved as-is.
- Ambiguous aliases (e.g. `Sporting`, `Inter`, `Real`, `Racing`, `United`) produce explicit `CLUB_AMBIGUOUS_ALIAS` findings rather than silently guessing.
- Unresolved Wikidata QIDs (`^Q\d+$`) produce explicit `CLUB_UNRESOLVED_QID` blocking errors.

### Candidate lifecycle integration
- High-level workflow:
  1. `candidate` starts in `FETCHED`.
  2. `normalize_candidate(candidate)` normalizes fields and career, records findings, and transitions `FETCHED → NORMALIZED`.
  3. `validate_candidate(candidate)` validates rules, records findings, populates `validation_warnings` and `validation_errors`.
  4. Decision rule:
     - If findings contain >= 1 `ERROR`: transitions `NORMALIZED → REVIEW_REQUIRED`.
     - If findings contain 0 `ERROR` (only `WARNING` or clean): transitions `NORMALIZED → VALIDATED`.
  5. `process_candidate(candidate)` orchestrates the full pipeline.
  6. Candidates never automatically transition to `READY` or `APPROVED`.

### Edge cases
- Returns to a previous club in distinct periods (e.g. Chelsea 2011-2014, Everton 2014-2017, Chelsea 2021-2022) are correctly recognized as valid.
- Legitimate loans overlapping within an owning contract period are treated as valid.
- Same-year transfers (`A.end_year == B.start_year`) and multi-club single seasons (e.g. 2018-2018) are valid.
- Ongoing careers with `end_year=None` are valid at the tail of a career but flagged as invalid when placed in the middle before subsequent contracts.
- Debut ages under 14 relative to `birth_year` are flagged as impossible ranges.
- Player alias collisions with existing production players are checked, distinguishing same-player updates from conflicting different players.

### Production dataset safety
- Absolute invariance: `data/players.json` is never modified.
- Dedicated regression test `test_production_dataset_safety_invariant` asserts SHA-256 hash invariance of `data/players.json` before and after processing batches of clean, dirty, and corrupt candidates.

### Tests
- Added 32 dedicated unit tests covering:
  - `tests/test_candidate_normalization.py` (14 tests)
  - `tests/test_candidate_validation.py` (18 tests)
- Full local test suite passes: 1086 passed, 27 skipped, 0 failures.

### Validation performed
- `pytest tests/test_candidate_normalization.py tests/test_candidate_validation.py` (32/32 passed)
- `pytest` on candidate core, adapters, career order, and dataset integrity (162/162 passed)
- `python -m tools.dev lint` (ruff: all checks passed)
- `python -m tools.dev typecheck` (mypy: 62 source files passed with 0 issues)
- `python -m tools.dev dataset-check` (650 players, 0 integrity issues)
- `python -m tools.dev check` (full local check suite passed: env, compileall, lint, mypy, tsc, vite build, dataset-check, client node tests, frontend tests, pytest)

### Limitations
- Does not resolve external Wikidata QIDs over the network (adapters preserve raw QIDs, and validation flags them for review).
- Does not perform network calls to fetch missing club information during validation.

### Deferred to #15 / #27
- Admin Review Queue UI and human decision workflow (Approve, Edit, Reject, Merge) deferred to #15.
- Complete internal provenance model (`source`, `source_id`, `retrieved_at`, confidence tracing) deferred to #27.

### Risk
Low: All changes are strictly additive within `services/` and `tests/`. No production player data or existing game engine flows are touched.
